### PR TITLE
Fix Gemini provider API call for content generation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1682,7 +1682,13 @@ class TextGeneratorApp(ctk.CTkFrame):
                         f"[{context}] Попытка {attempt + 1}/{retries} отправки запроса Gemini ключом {key_short}",
                         "DEBUG",
                     )
-                    resp = requests.post(url, params=params, headers=headers, json=payload, timeout=(10, 30))
+                    resp = requests.post(
+                        url,
+                        params=params,
+                        headers=headers,
+                        json=payload,
+                        timeout=(10, 120),
+                    )
                     self.log_message(
                         f"[{context}] Ответ Gemini {resp.status_code} за {getattr(resp, 'elapsed', datetime.timedelta(0)).total_seconds():.2f}с",
                         "DEBUG",
@@ -1748,6 +1754,11 @@ class TextGeneratorApp(ctk.CTkFrame):
                                     f"[{context}] Не удалось обработать RetryInfo для ключа {key_short}",
                                     "DEBUG",
                                 )
+                except requests.exceptions.Timeout as e:
+                    self.log_message(
+                        f"[{context}] Таймаут Gemini API: {e}",
+                        "WARNING",
+                    )
                 except Exception as e:
                     self.log_message(f"[{context}] Gemini API request failed: {e}", "ERROR")
                 if attempt + 1 < retries:

--- a/main.py
+++ b/main.py
@@ -661,7 +661,15 @@ class TextGeneratorApp(ctk.CTkFrame):
                     {"date": today, "used_today": 0, "next_allowed_ts": 0.0, "window_count": 0},
                 )
                 if info.get("date") != today:
-                    info.update({"date": today, "used_today": 0, "next_allowed_ts": 0.0, "window_count": 0})
+                    info.update(
+                        {
+                            "date": today,
+                            "used_today": 0,
+                            "next_allowed_ts": 0.0,
+                            "window_count": 0,
+                        }
+                    )
+                wait = 0.0
                 if info["used_today"] >= 250:
                     return False
                 now = time.time()
@@ -1616,15 +1624,14 @@ class TextGeneratorApp(ctk.CTkFrame):
     def call_gemini_api(self, api_key_used_for_call, prompt_text, retries=3, delay_seconds=0.5):
         if not self._before_gemini_call(api_key_used_for_call):
             return "GEMINI_KEY_EXHAUSTED"
-        url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent"
-        params = {"key": api_key_used_for_call}
-        headers = {"Content-Type": "application/json"}
+        url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+        headers = {"Content-Type": "application/json", "X-goog-api-key": api_key_used_for_call}
         payload = {"contents": [{"parts": [{"text": prompt_text}]}]}
         for attempt in range(retries):
             if self.stop_event.is_set():
                 return None
             try:
-                resp = requests.post(url, params=params, headers=headers, json=payload, timeout=30)
+                resp = requests.post(url, headers=headers, json=payload, timeout=30)
                 if resp.status_code == 200:
                     data = resp.json()
                     text = (

--- a/main.py
+++ b/main.py
@@ -65,6 +65,7 @@ MAX_CONCURRENT_PROJECTS = 3
 GLOBAL_THREAD_SEMAPHORE = threading.Semaphore(MAX_THREADS)
 GLOBAL_PROJECT_SEMAPHORE = threading.Semaphore(MAX_CONCURRENT_PROJECTS)
 PER_KEY_CONCURRENCY = 10
+MAX_API_KEYS = 100
 BAD_API_KEYS_FILE = "BAD_API.txt"
 # Limit the amount of lines kept in the GUI log to avoid slowdown
 MAX_LOG_LINES = 500
@@ -1004,6 +1005,12 @@ class TextGeneratorApp(ctk.CTkFrame):
             return []
         if not keys:
             messagebox.showerror("Ошибка", f"В файле {path} нет валидных строк с ключами")
+        if len(keys) > MAX_API_KEYS:
+            self.log_message(
+                f"Загружено {len(keys)} ключей, используются только первые {MAX_API_KEYS}",
+                "WARNING",
+            )
+            keys = keys[:MAX_API_KEYS]
         return keys
 
     def _prepare_api_keys(self):

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ import atexit
 import signal
 # from multiprocessing import Process, freeze_support  # Multiprocessing no longer used
 from collections import deque, defaultdict
+import itertools
 
 if getattr(sys, "frozen", False):
     APP_DIR = os.path.dirname(sys.executable)
@@ -774,9 +775,10 @@ class TextGeneratorApp(ctk.CTkFrame):
         per_key = self._current_per_key_concurrency()
         if active_keys_for_queue:
             random.shuffle(active_keys_for_queue)
-            for _ in range(per_key):
-                for key_str in active_keys_for_queue:
-                    new_queue.put(key_str)
+            rr_cycle = itertools.cycle(active_keys_for_queue)
+            total_entries = per_key * len(active_keys_for_queue)
+            for _ in range(total_entries):
+                new_queue.put(next(rr_cycle))
             self.log_message(
                 f"Очередь API ключей обновлена. Активных ключей: {len(active_keys_for_queue)}",
                 "INFO",

--- a/main.py
+++ b/main.py
@@ -1982,6 +1982,18 @@ class TextGeneratorApp(ctk.CTkFrame):
             self.log_message(f"{log_prefix} H1 (оригинал): '{original_h1_text}'")
             filepath_to_save = self.get_unique_filepath(original_h1_text)
 
+            # Pause to respect Gemini rate limits after plan (H1) generation
+            self.log_message(
+                f"{log_prefix} Ожидание 65 секунд после генерации плана перед созданием тела статьи...",
+                "DEBUG",
+            )
+            if self.stop_event.wait(65):
+                self.log_message(
+                    f"{log_prefix} Ожидание после плана прервано сигналом остановки.",
+                    "DEBUG",
+                )
+                return False
+
             def generate_random_body_prompt(current_selected_lang, current_keyword_phrase, current_original_h1_text):
                 # Рандомизация объема вступления
                 intro_word_count = random.randint(150, 300)  # Вступление может быть от 150 до 300 слов

--- a/main.py
+++ b/main.py
@@ -1616,14 +1616,15 @@ class TextGeneratorApp(ctk.CTkFrame):
     def call_gemini_api(self, api_key_used_for_call, prompt_text, retries=3, delay_seconds=0.5):
         if not self._before_gemini_call(api_key_used_for_call):
             return "GEMINI_KEY_EXHAUSTED"
-        url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
-        headers = {"Content-Type": "application/json", "X-goog-api-key": api_key_used_for_call}
+        url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent"
+        params = {"key": api_key_used_for_call}
+        headers = {"Content-Type": "application/json"}
         payload = {"contents": [{"parts": [{"text": prompt_text}]}]}
         for attempt in range(retries):
             if self.stop_event.is_set():
                 return None
             try:
-                resp = requests.post(url, headers=headers, json=payload, timeout=30)
+                resp = requests.post(url, params=params, headers=headers, json=payload, timeout=30)
                 if resp.status_code == 200:
                     data = resp.json()
                     text = (

--- a/main.py
+++ b/main.py
@@ -1549,6 +1549,10 @@ class TextGeneratorApp(ctk.CTkFrame):
             to_wait = PER_KEY_CALL_INTERVAL - (time.time() - last_ts)
             if to_wait > 0:
                 time.sleep(to_wait)
+            self.log_message("Глобальная задержка 10с перед вызовом OpenAI", "DEBUG")
+            if self.stop_event.wait(10):
+                self.log_message("Глобальная задержка перед OpenAI прервана", "DEBUG")
+                return None
             try:
                 raw_response = client_instance.chat.completions.with_raw_response.create(model=DEFAULT_MODEL,
         messages=messages, timeout=300)
@@ -1656,6 +1660,10 @@ class TextGeneratorApp(ctk.CTkFrame):
                 "DEBUG",
             )
             return "GEMINI_KEY_EXHAUSTED"
+        self.log_message(f"[{context}] Глобальная задержка 10с перед запросом Gemini", "DEBUG")
+        if self.stop_event.wait(10):
+            self.log_message(f"[{context}] Глобальная задержка перед Gemini прервана", "DEBUG")
+            return None
         url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
         params = {"key": api_key_used_for_call}
         headers = {"Content-Type": "application/json"}

--- a/main.py
+++ b/main.py
@@ -518,6 +518,8 @@ class TextGeneratorApp(ctk.CTkFrame):
                     "WARNING")
 
     def log_message(self, message, level="INFO"):
+        if level == "DEBUG":
+            return
         if getattr(self, 'silent_stop', False) and self.stop_event.is_set():
             allowed = [
                 "Генерация остановлена",
@@ -754,8 +756,6 @@ class TextGeneratorApp(ctk.CTkFrame):
         self._save_api_key_statuses()
 
     def _current_per_key_concurrency(self):
-        if self.provider_var.get() == PROVIDER_GEMINI:
-            return 1
         return PER_KEY_CONCURRENCY
 
     def _repopulate_available_api_key_queue(self):
@@ -774,8 +774,8 @@ class TextGeneratorApp(ctk.CTkFrame):
         per_key = self._current_per_key_concurrency()
         if active_keys_for_queue:
             random.shuffle(active_keys_for_queue)
-            for key_str in active_keys_for_queue:
-                for _ in range(per_key):
+            for _ in range(per_key):
+                for key_str in active_keys_for_queue:
                     new_queue.put(key_str)
             self.log_message(
                 f"Очередь API ключей обновлена. Активных ключей: {len(active_keys_for_queue)}",

--- a/main.py
+++ b/main.py
@@ -65,7 +65,6 @@ MAX_CONCURRENT_PROJECTS = 3
 GLOBAL_THREAD_SEMAPHORE = threading.Semaphore(MAX_THREADS)
 GLOBAL_PROJECT_SEMAPHORE = threading.Semaphore(MAX_CONCURRENT_PROJECTS)
 PER_KEY_CONCURRENCY = 10
-MAX_API_KEYS = 100
 BAD_API_KEYS_FILE = "BAD_API.txt"
 # Limit the amount of lines kept in the GUI log to avoid slowdown
 MAX_LOG_LINES = 500
@@ -1005,12 +1004,6 @@ class TextGeneratorApp(ctk.CTkFrame):
             return []
         if not keys:
             messagebox.showerror("Ошибка", f"В файле {path} нет валидных строк с ключами")
-        if len(keys) > MAX_API_KEYS:
-            self.log_message(
-                f"Загружено {len(keys)} ключей, используются только первые {MAX_API_KEYS}",
-                "WARNING",
-            )
-            keys = keys[:MAX_API_KEYS]
         return keys
 
     def _prepare_api_keys(self):

--- a/main.py
+++ b/main.py
@@ -93,7 +93,7 @@ PROVIDER_GEMINI = "Gemini 2.5 Flash"
 # Файлы для провайдера Gemini
 GEMINI_USAGE_FILE = "gemini_key_usage.json"
 EXHAUSTED_GEMINI_KEYS_FILE = "exhausted-limit-keys.txt"
-GEMINI_USAGE_LOCK = threading.Lock()
+GEMINI_USAGE_LOCK = threading.RLock()
 
 # Файлы для совместного использования API ключей и списка проектов
 SHARED_KEYS_FILE = "shared_keys.txt"
@@ -1672,6 +1672,10 @@ class TextGeneratorApp(ctk.CTkFrame):
                 resp = requests.post(url, params=params, headers=headers, json=payload, timeout=(10, 30))
                 self.log_message(
                     f"[{context}] Ответ Gemini {resp.status_code} за {getattr(resp, 'elapsed', datetime.timedelta(0)).total_seconds():.2f}с",
+                    "DEBUG",
+                )
+                self.log_message(
+                    f"[{context}] Тело ответа Gemini (первые 200 символов): {resp.text[:200]}",
                     "DEBUG",
                 )
                 if resp.status_code == 200:


### PR DESCRIPTION
## Summary
- Fix Gemini provider requests by passing API key as query parameter and using supported `gemini-1.5-flash` endpoint

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68979816a2f8832bb40b89c7ac703559