### PR TITLE
Remove code fence marker lines from generated HTML

### DIFF
--- a/main.py
+++ b/main.py
@@ -328,9 +328,11 @@ def normalize_html(html):
 
     cleaned = re.sub(r"<h([1-6])>(.*?)</h\1>", split_header, cleaned, flags=re.DOTALL)
 
-    # Remove any lines containing `html to strip code fences from the output
+    # Remove any lines containing `html or ``` to strip code fences from the output
     cleaned = "\n".join(
-        line for line in cleaned.splitlines() if "`html" not in line
+        line
+        for line in cleaned.splitlines()
+        if "`html" not in line and "```" not in line
     )
 
     cleaned = cleaned.strip()

--- a/main.py
+++ b/main.py
@@ -327,6 +327,12 @@ def normalize_html(html):
         return match.group(0)
 
     cleaned = re.sub(r"<h([1-6])>(.*?)</h\1>", split_header, cleaned, flags=re.DOTALL)
+
+    # Remove any lines containing `html to strip code fences from the output
+    cleaned = "\n".join(
+        line for line in cleaned.splitlines() if "`html" not in line
+    )
+
     cleaned = cleaned.strip()
     return "<html>\n<body>\n" + cleaned + "\n</body>\n</html>"
 


### PR DESCRIPTION
## Summary
- Strip lines containing `\`html` from generated content to remove code fence markers.

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_689da2aa46f4832ba427c3e3cf67abfb