### PR TITLE
Improve LLM logging and prompt handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -286,6 +286,7 @@ def db_set_kv(key: str, value: str) -> None:
 _ADMIN_DEBUG_LOCK = threading.Lock()
 _ADMIN_DEBUG_ENABLED: Optional[bool] = None
 _ADMIN_DEBUG_LOGS: List[str] = []
+_ADMIN_DEBUG_SEQ: int = 0
 
 def admin_debug_enabled() -> bool:
     global _ADMIN_DEBUG_ENABLED
@@ -308,8 +309,12 @@ def admin_debug_set(enabled: bool) -> None:
 def admin_debug_log(message: str) -> None:
     if not admin_debug_enabled():
         return
-    line = f"[{now_str()}] {message}"
+    global _ADMIN_DEBUG_SEQ
+    timestamp = now_str()
     with _ADMIN_DEBUG_LOCK:
+        _ADMIN_DEBUG_SEQ += 1
+        seq = _ADMIN_DEBUG_SEQ
+        line = f"[{timestamp} #{seq:04d}] {message}"
         _ADMIN_DEBUG_LOGS.append(line)
         if len(_ADMIN_DEBUG_LOGS) > 200:
             del _ADMIN_DEBUG_LOGS[:-200]
@@ -319,6 +324,43 @@ def admin_debug_drain() -> List[str]:
         logs = list(_ADMIN_DEBUG_LOGS)
         _ADMIN_DEBUG_LOGS.clear()
     return logs
+
+
+def _split_text_for_telegram(text: str, limit: int = 3500) -> List[str]:
+    if not text:
+        return []
+    try:
+        limit_val = int(limit)
+    except (TypeError, ValueError):
+        limit_val = 3500
+    limit = max(1, limit_val)
+    parts: List[str] = []
+    current: List[str] = []
+    current_len = 0
+
+    lines = text.split('\n')
+    for idx, line in enumerate(lines):
+        suffix = '\n' if idx < len(lines) - 1 else ''
+        chunk = line + suffix
+        while chunk:
+            available = limit - current_len
+            if available <= 0:
+                parts.append("".join(current))
+                current = []
+                current_len = 0
+                available = limit
+            take = min(len(chunk), available)
+            current.append(chunk[:take])
+            current_len += take
+            chunk = chunk[take:]
+            if current_len >= limit:
+                parts.append("".join(current))
+                current = []
+                current_len = 0
+    if current:
+        parts.append("".join(current))
+
+    return [p for p in parts if p]
 
 # =========================================================
 # ==============  OPENAI (карусель ключей)  ===============
@@ -373,23 +415,27 @@ def _message_content_to_text(content: Any) -> str:
         text = " ".join(texts)
     else:
         text = str(content or "")
-    return clip(text.strip(), 600)
+    return text.strip()
 
 
-def _format_messages_for_log(messages: List[Dict[str, Any]], max_len: int = 1600) -> str:
+def _format_messages_for_log(messages: List[Dict[str, Any]], max_len: int = 3200) -> str:
     lines: List[str] = []
     total = 0
+    truncated = False
     for msg in messages or []:
         role = str(msg.get("role") or "?")
         text = _message_content_to_text(msg.get("content"))
         if not text:
             text = "(пусто)"
         line = f"{role}: {text}"
-        lines.append(line)
-        total += len(line) + 1
-        if total > max_len:
-            lines.append("…(обрезано)")
+        projected = total + len(line) + (1 if lines else 0)
+        if projected > max_len:
+            truncated = True
             break
+        lines.append(line)
+        total = projected
+    if truncated:
+        lines.append(f"…(обрезано, лимит {max_len} символов)")
     return "\n".join(lines)
 
 
@@ -857,24 +903,34 @@ def _parse_yesno_list(raw: str) -> Tuple[Optional[str], List[str]]:
 
 
 def llm_yesno(question: str, purpose: str) -> str:
+    system_prompt = (
+        "Ты аккуратный русскоязычный ассистент контроля качества. "
+        "Отвечай ТОЛЬКО одним словом: «Да» или «Нет». Никаких комментариев."
+    )
     base_messages = [
-        {"role": "system",
-         "content": "Ты аккуратный русскоязычный ассистент контроля качества. "
-                    "Отвечай ТОЛЬКО одним словом: «Да» или «Нет». Никаких комментариев."},
+        {"role": "system", "content": system_prompt},
         {"role": "user", "content": question}
     ]
     raw = _call_openai_with_keys(messages=base_messages, max_tokens=4, temperature=0.0, purpose=purpose)
     yn = _normalize_yesno(raw)
     if yn in ("Да", "Нет"):
         return yn
-    reminder_messages = base_messages + [
-        {"role": "user", "content": "Напомню: нужно одно слово — «Да» или «Нет»."}
+    reminder_text = (question or "").strip()
+    if reminder_text:
+        reminder_text += "\n\nОтветь одним словом: «Да» или «Нет»."
+    else:
+        reminder_text = "Ответь одним словом: «Да» или «Нет»."
+    reminder_messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": reminder_text}
     ]
     raw2 = _call_openai_with_keys(messages=reminder_messages, max_tokens=4, temperature=0.0, purpose=f"{purpose} (retry)")
     yn2 = _normalize_yesno(raw2)
     if yn2 in ("Да", "Нет"):
         return yn2
-    raise RuntimeError(f"[{purpose}] Не удалось интерпретировать ответ модели: {raw!r}")
+    raise RuntimeError(
+        f"[{purpose}] Не удалось интерпретировать ответы модели: первичный={raw!r}, повторный={raw2!r}"
+    )
 
 def llm_text(question: str, purpose: str, max_tokens: int = 256) -> str:
     messages = [
@@ -2375,20 +2431,18 @@ async def maybe_send_admin_debug_logs(message: Message, heading: str = "🛠 Л�
     logs = admin_debug_drain()
     if not logs:
         return
-    max_len = 3500
-    chunk: List[str] = []
-    current_len = 0
-    title = heading
-    for line in logs:
-        if current_len + len(line) + 1 > max_len and chunk:
-            await message.answer(f"{title}:\n" + "\n".join(chunk))
-            chunk = []
-            current_len = 0
-            title = "🛠 Лог LLM (продолжение)"
-        chunk.append(line)
-        current_len += len(line) + 1
-    if chunk:
-        await message.answer(f"{title}:\n" + "\n".join(chunk))
+    base_limit = max(1000, 3800 - len(heading))
+    for log in logs:
+        pieces = _split_text_for_telegram(log, limit=base_limit)
+        if not pieces:
+            continue
+        total_parts = len(pieces)
+        for idx, piece in enumerate(pieces, start=1):
+            if total_parts == 1:
+                text = f"{heading}:\n{piece}"
+            else:
+                text = f"{heading} (часть {idx}/{total_parts}):\n{piece}"
+            await message.answer(text)
 
 async def setup_menu_commands(bot: Bot, chat_id: Optional[int] = None):
     await bot.set_my_commands(

--- a/main.py
+++ b/main.py
@@ -1874,12 +1874,15 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
     try:
         sections_for_prompt: List[Tuple[Optional[int], str, List[str]]] = []
         for sec in article_sections:
-            heading_text = sec.get("heading") or ""
+            heading_raw = sec.get("heading") or ""
+            heading_clean = strip_invisible(heading_raw).strip()
             level = sec.get("level")
             body_lines = [ln for ln in (sec.get("body") or []) if (ln or "").strip()]
-            if not heading_text and not body_lines:
+            if not heading_clean and not body_lines:
                 continue
-            sections_for_prompt.append((level, heading_text, body_lines))
+            if not heading_clean:
+                continue
+            sections_for_prompt.append((level, heading_raw, body_lines))
         heading_pairs = [(lvl, txt) for (lvl, txt) in headings if (txt or "").strip()]
         body_blocks = [t for t in body_texts if (t or "").strip()]
         body_sample_lines = _prepare_text_lines_for_prompt(body_blocks)

--- a/main.py
+++ b/main.py
@@ -1418,28 +1418,64 @@ def _prepare_text_lines_for_prompt(text: Union[str, Sequence[str], None]) -> Lis
             if chunk is None:
                 continue
             candidates.append(str(chunk))
+
     lines: List[str] = []
     for chunk in candidates:
-        for line in re.split(r'(?:\r?\n)+', chunk):
-            cleaned = clean_for_prompt(line)
+        normalized = strip_invisible(chunk or "")
+        if not normalized:
+            continue
+        normalized = normalized.replace("\r\n", "\n").replace("\r", "\n")
+        chunk_lines = []
+        for raw_line in normalized.split("\n"):
+            cleaned = raw_line.strip()
             if cleaned:
-                lines.append(cleaned)
+                chunk_lines.append(cleaned)
+        if not chunk_lines:
+            continue
+        if lines:
+            lines.append("")
+        lines.extend(chunk_lines)
     return lines
 
 
 def _format_text_for_prompt(
     text: Union[str, Sequence[str], None],
-    prefix: str = "Текст:",
+    prefix: str = "Text",
     max_chars: Optional[int] = None,
 ) -> str:
     lines = _prepare_text_lines_for_prompt(text)
     if not lines:
-        body = "—"
-    else:
-        body = "\n".join(lines)
-        if max_chars is not None:
-            body = clip(body, max_chars)
-    return f"{prefix}\n{body}"
+        return f"{prefix}:\n—"
+
+    blocks: List[List[str]] = []
+    current: List[str] = []
+    for line in lines:
+        if line == "":
+            if current:
+                blocks.append(current)
+                current = []
+            continue
+        current.append(line)
+    if current:
+        blocks.append(current)
+
+    display_lines: List[str] = []
+    multi_block = len(blocks) > 1
+    for idx, block in enumerate(blocks, 1):
+        label = f"{prefix} #{idx}:" if multi_block else f"{prefix}:"
+        display_lines.append(label)
+        display_lines.extend(block)
+        if idx != len(blocks):
+            display_lines.append("")
+
+    body_text = "\n".join(display_lines)
+    if max_chars is not None and len(body_text) > max_chars:
+        visible = body_text[:max_chars].rstrip()
+        body_text = (
+            f"{visible}\n"
+            f"[Обрезано: показано {max_chars} из {len(body_text)} символов]"
+        )
+    return body_text
 
 
 def _format_headings_for_prompt(headings: Sequence[Tuple[Optional[int], str]]) -> str:
@@ -1452,9 +1488,14 @@ def _format_headings_for_prompt(headings: Sequence[Tuple[Optional[int], str]]) -
         else:
             lvl, text = None, entry  # type: ignore[assignment]
         label = f"H{lvl}" if isinstance(lvl, int) and 1 <= lvl <= 6 else "H?"
-        text_clean = clean_for_prompt(text)
-        if text_clean:
-            text_clean = clip(text_clean, 400)
+        text_clean = strip_invisible(text or "")
+        text_clean = text_clean.strip()
+        if text_clean and len(text_clean) > 600:
+            trimmed = text_clean[:600].rstrip()
+            text_clean = (
+                f"{trimmed}\n"
+                f"[Обрезано: показано 600 из {len(text_clean)} символов]"
+            )
         formatted.append(f"{label}: {text_clean or '—'}")
     return "\n".join(formatted) if formatted else "—"
 
@@ -1464,7 +1505,7 @@ def build_article_headings_vs_text_prompt(
     body: Union[str, Sequence[str], None],
 ) -> str:
     htxt = _format_headings_for_prompt(headings)
-    body_block = _format_text_for_prompt(body, prefix="Текст:", max_chars=ART_PROMPT_MAX_CHARS)
+    body_block = _format_text_for_prompt(body, prefix="Text", max_chars=ART_PROMPT_MAX_CHARS)
     return (
         "Ты проверяешь совпадение языка заголовков и основного текста.\n"
         "Каждая строка в блоке <HEADINGS> начинается с H1:, H2: и т.д.\n"
@@ -1472,6 +1513,7 @@ def build_article_headings_vs_text_prompt(
         "Определи доминирующий язык блока <TEXT> по грамматике и служебным словам (диакритику игнорируй: á→a, ü→u и т.п.).\n"
         "Игнорируй бренды, домены/URL, аббревиатуры, числа, валюты и одиночные заимствования.\n"
         "Сравни язык каждого заголовка из <HEADINGS> с языком <TEXT>.\n"
+        "Каждый фрагмент текста в <TEXT> начинается строкой «Text:» (если он один) или «Text #N:» (если их несколько).\n"
         "Если хотя бы один заголовок на другом языке — ответь «Нет». Если все совпадает — ответь «Да».\n"
         "Отвечай строго одним словом «Да» или «Нет». Никаких комментариев.\n"
         f"\n<HEADINGS>\n{htxt}\n</HEADINGS>"
@@ -1483,7 +1525,7 @@ def build_article_list_problem_headings_prompt(
     body: Union[str, Sequence[str], None],
 ) -> str:
     htxt = _format_headings_for_prompt(headings)
-    body_block = _format_text_for_prompt(body, prefix="Текст:", max_chars=ART_PROMPT_MAX_CHARS)
+    body_block = _format_text_for_prompt(body, prefix="Text", max_chars=ART_PROMPT_MAX_CHARS)
     return (
         "Определи ДОМИНИРУЮЩИЙ язык <TEXT> СТРОГО по блоку <TEXT> ниже. Язык промпта на котором это написано не причем. Не упоминай его."
         "Игнорируй язык этих инструкций и всё, что вне тегов. Только язык с <TEXT>. "
@@ -1491,6 +1533,7 @@ def build_article_list_problem_headings_prompt(
         "Игнорируй бренды/имена, домены/URL, аббревиатуры, числа/валюты и одиночные англ. заимствования.\n"
         "Сравни каждый заголовок из <HEADINGS> с языком <TEXT>. "
         "Каждая строка в <HEADINGS> имеет вид H1:, H2: и т.д.\n"
+        "Каждый фрагмент текста в <TEXT> начинается строкой «Text:» (если он один) или «Text #N:» (если их несколько).\n"
         "Если заголовок совпадает по языку — пропусти. "
         "Если нет — укажи точную проблему.\n"
         "Начни ответ с «Да», если найдены ошибки, иначе ответь ровно «Нет».\n"
@@ -1519,6 +1562,7 @@ def build_slug_consistency_prompt(
     body.append("SLUG пишут без диакритики — это нормально, если он всё равно про ту же тему.")
     body.append("Если SLUG заметно про другую тему или язык — ответь «Нет». Иначе ответь «Да».")
     body.append("Отвечай строго одним словом «Да» или «Нет». Никаких пояснений.")
+    body.append("Каждый текстовый фрагмент ниже помечен строкой «Text:» (если он один) или «Text #N:» (если их несколько).")
     body.append("")
     body.append(slug or "—")
     body.append("")
@@ -1527,7 +1571,7 @@ def build_slug_consistency_prompt(
     if mk: body.append(f"MK: {mk}")
     if h1: body.append(f"H1: {h1}")
     body.append("")
-    body.append(_format_text_for_prompt(content, prefix="Текст:", max_chars=EEAT_PROMPT_MAX_CHARS))
+    body.append(_format_text_for_prompt(content, prefix="Text", max_chars=EEAT_PROMPT_MAX_CHARS))
     return "\n".join(body)
 
 def _format_meta_block(mt: str, md: str, mk: str, h1: str) -> str:
@@ -1539,7 +1583,7 @@ def _format_meta_block(mt: str, md: str, mk: str, h1: str) -> str:
 
 
 def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content: Union[str, Sequence[str], None]) -> str:
-    content_block = _format_text_for_prompt(content, prefix="Текст:", max_chars=EEAT_PROMPT_MAX_CHARS)
+    content_block = _format_text_for_prompt(content, prefix="Text", max_chars=EEAT_PROMPT_MAX_CHARS)
     meta_block = _format_meta_block(mt, md, mk, h1)
     return (
         "Ты проверяешь, совпадает ли язык MT/MD/MK/H1 с языком текста секции.\n"
@@ -1547,6 +1591,7 @@ def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content:
         "Определи доминирующий язык <CONTENT> по грамматике и служебным словам (диакритику игнорируй: á→a, ü→u и т.п.).\n"
         "Игнорируй бренды, домены/URL, числа, валюты и одиночные заимствования.\n"
         "Сравни язык MT, MD, MK и H1 с языком <CONTENT>.\n"
+        "Каждый фрагмент текста в <CONTENT> начинается строкой «Text:» (если он один) или «Text #N:» (если их несколько).\n"
         "Если хотя бы один элемент явно на другом языке — ответь «Нет». Если всё совпадает — ответь «Да».\n"
         "Отвечай строго одним словом «Да» или «Нет». Никаких пояснений.\n"
         f"\n<META>\n{meta_block}\n</META>"
@@ -1555,13 +1600,14 @@ def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content:
 
 
 def build_section_lang_list_bad_prompt(mt: str, md: str, mk: str, h1: str, content: Union[str, Sequence[str], None]) -> str:
-    content_block = _format_text_for_prompt(content, prefix="Текст:", max_chars=EEAT_PROMPT_MAX_CHARS)
+    content_block = _format_text_for_prompt(content, prefix="Text", max_chars=EEAT_PROMPT_MAX_CHARS)
     meta_block = _format_meta_block(mt, md, mk, h1)
     return (
         "Если найдёшь несоответствие языков — ответь «Да», иначе ответь ровно «Нет».\n"
         "Если ответ «Да», перечисли ТОЛЬКО ярлыки из набора MT | MD | MK | H1, разделяя их через « | ». Никаких пояснений.\n"
         "Анализируй исключительно данные внутри тегов <META> и <CONTENT> ниже. Игнорируй язык этих инструкций."
         "\nПомни: бренды, домены и одиночные заимствованные слова не считаются сменой языка; оценивай основную часть текста.\n"
+        "Каждый фрагмент текста в <CONTENT> начинается строкой «Text:» (если он один) или «Text #N:» (если их несколько).\n"
         f"\n<META>\n{meta_block}\n</META>"
         f"\n\n<CONTENT>\n{content_block}\n</CONTENT>"
     )

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ DOCX Validator Telegram Bot — Articles & EEAT (Zoho Writer API)
 # ===============  НАСТРОЙКА (ОБЯЗАТЕЛЬНО)  ===============
 # =========================================================
 import os  # <— важно: os должен быть раньше использования
+import copy
 
 # 1) Токен телеграм‑бота
 BOT_TOKEN = "7506878864:AAEsjLOa0yT-WfB-4AKhrhFA3xopuJzaHPY"
@@ -358,6 +359,71 @@ def _messages_preview(messages: List[Dict[str, Any]], limit: int = 600) -> str:
     joined = " | ".join(parts)
     return clip(joined, limit)
 
+
+def _message_content_to_text(content: Any) -> str:
+    if isinstance(content, list):
+        texts: List[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                txt = str(part.get("text") or "")
+            else:
+                txt = str(part)
+            if txt:
+                texts.append(txt.strip())
+        text = " ".join(texts)
+    else:
+        text = str(content or "")
+    return clip(text.strip(), 600)
+
+
+def _format_messages_for_log(messages: List[Dict[str, Any]], max_len: int = 1600) -> str:
+    lines: List[str] = []
+    total = 0
+    for msg in messages or []:
+        role = str(msg.get("role") or "?")
+        text = _message_content_to_text(msg.get("content"))
+        if not text:
+            text = "(пусто)"
+        line = f"{role}: {text}"
+        lines.append(line)
+        total += len(line) + 1
+        if total > max_len:
+            lines.append("…(обрезано)")
+            break
+    return "\n".join(lines)
+
+
+def _format_exception(ex: BaseException) -> str:
+    name = type(ex).__name__
+    return f"{name}: {ex}"
+
+
+def _log_llm_chat(label: str,
+                  key_masked: str,
+                  round_idx: int,
+                  attempt_idx: int,
+                  messages: List[Dict[str, Any]],
+                  response_text: Optional[str] = None,
+                  error: Optional[BaseException] = None,
+                  method: Optional[str] = None) -> None:
+    header = [f"LLM[{label}] (ключ {key_masked}, попытка {attempt_idx}, раунд {round_idx}"]
+    if method:
+        header.append(f", метод {method}")
+    header.append(")")
+    prompt_text = _format_messages_for_log(messages)
+    if error is None:
+        resp = trim(response_text or "", 600)
+        if not resp:
+            resp = "(пустой ответ)"
+        admin_debug_log(
+            "".join(header) + f"\nЗапрос:\n{prompt_text}\nОтвет:\n{resp}"
+        )
+    else:
+        err_txt = trim(_format_exception(error), 400)
+        admin_debug_log(
+            "".join(header) + f"\nЗапрос:\n{prompt_text}\nОтвет:\nОшибка: {err_txt}\nПочему так?"
+        )
+
 def _responses_input_from_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     formatted: List[Dict[str, Any]] = []
     for msg in messages or []:
@@ -682,9 +748,6 @@ def _call_openai_with_keys(messages: List[Dict],
                            temperature: float = 0.0,
                            purpose: str = "") -> str:
     label = purpose or "general"
-    prompt_preview = _messages_preview(messages, limit=500)
-    if prompt_preview:
-        admin_debug_log(f"LLM[{label}] Prompt: {prompt_preview}")
 
     keys = db_list_keys()
     env_sk = os.environ.get("OPENAI_API_KEY")
@@ -692,41 +755,59 @@ def _call_openai_with_keys(messages: List[Dict],
         keys.append(env_sk)
 
     if not keys:
-        admin_debug_log(f"LLM[{label}] Нет доступных ключей.")
+        admin_debug_log(
+            f"LLM[{label}] (без ключей)\nЗапрос:\n(нет доступных ключей)\n"
+            "Ответ:\nОшибка: Нет ни одного OpenAI API Key\nПочему так?"
+        )
         raise KeysExhaustedError("Нет ни одного OpenAI API Key")
 
     last_exc = None
     for round_idx in (1, 2):
         for sk in keys:
+            key_masked = mask_secret(sk, 8, 6)
             try:
                 client = _openai_client_for_key(sk)
-                local_exc = None
-                key_masked = mask_secret(sk, 8, 6)
-                for attempt in range(LLM_MAX_RETRIES_LOCAL + 1):
-                    try:
-                        admin_debug_log(
-                            f"LLM[{label}] Ключ {key_masked}: попытка {attempt + 1} (раунд {round_idx})"
-                        )
-                        answer, method = _invoke_openai(client, messages, max_tokens, temperature)
-                        if isinstance(answer, str) and answer.strip():
-                            text = answer.strip()
-                            admin_debug_log(
-                                f"LLM[{label}] Ключ {key_masked}: успех через {method}, ответ: {trim(text, 500)}"
-                            )
-                            return text
-                        raise RuntimeError("Пустой ответ модели OpenAI")
-                    except Exception as ex:
-                        local_exc = ex
-                        admin_debug_log(
-                            f"LLM[{label}] Ключ {key_masked}: ошибка попытки {attempt + 1}: {ex}"
-                        )
-                        time.sleep(0.2 * (attempt + 1))
-                last_exc = local_exc
             except Exception as ex:
                 last_exc = ex
-                admin_debug_log(f"LLM[{label}] Ошибка при использовании ключа {key_masked}: {ex}")
+                admin_debug_log(f"LLM[{label}] Ошибка при инициализации ключа {key_masked}: {ex}")
                 continue
-    admin_debug_log(f"LLM[{label}] Ключи исчерпаны: {last_exc}")
+
+            local_exc: Optional[Exception] = None
+            for attempt in range(LLM_MAX_RETRIES_LOCAL + 1):
+                payload = copy.deepcopy(messages or [])
+                try:
+                    answer, method = _invoke_openai(client, payload, max_tokens, temperature)
+                    if isinstance(answer, str) and answer.strip():
+                        text = answer.strip()
+                        _log_llm_chat(
+                            label=label,
+                            key_masked=key_masked,
+                            round_idx=round_idx,
+                            attempt_idx=attempt + 1,
+                            messages=payload,
+                            response_text=text,
+                            method=method,
+                        )
+                        return text
+                    raise RuntimeError("Пустой ответ модели OpenAI")
+                except Exception as ex:
+                    local_exc = ex
+                    _log_llm_chat(
+                        label=label,
+                        key_masked=key_masked,
+                        round_idx=round_idx,
+                        attempt_idx=attempt + 1,
+                        messages=payload,
+                        error=ex,
+                    )
+                    time.sleep(0.2 * (attempt + 1))
+
+            last_exc = local_exc
+    err_text = trim(_format_exception(last_exc) if last_exc else "Неизвестная ошибка", 400)
+    admin_debug_log(
+        f"LLM[{label}] (исчерпаны ключи)\nЗапрос:\n(повторяющийся запрос)\n"
+        f"Ответ:\nОшибка: {err_text}\nПочему так?"
+    )
     raise KeysExhaustedError(f"Не удалось получить ответ от модели: {last_exc}")
 
 def _normalize_yesno(s: str) -> Optional[str]:
@@ -742,19 +823,54 @@ def _normalize_yesno(s: str) -> Optional[str]:
     if t.startswith("нет"): return "Нет"
     return None
 
+
+def _split_yesno_details(text: str) -> Tuple[Optional[str], str]:
+    if text is None:
+        return None, ""
+    stripped = (text or "").strip()
+    if not stripped:
+        return None, ""
+    m = re.match(r'^(да|нет)\b', stripped, flags=re.I)
+    if not m:
+        return None, stripped
+    answer = "Да" if m.group(1).lower().startswith("да") else "Нет"
+    remainder = stripped[m.end():]
+    remainder = re.sub(r'^[\s\.:;,\-–—]+', '', remainder)
+    return answer, remainder.strip()
+
+
+def _parse_yesno_list(raw: str) -> Tuple[Optional[str], List[str]]:
+    answer, remainder = _split_yesno_details(raw)
+    if answer == "Нет":
+        return answer, []
+    text = remainder if remainder else ((raw or "").strip())
+    if not text:
+        return answer, []
+    tokens = [t.strip() for t in re.split(r"[|,\n]+", text) if t and t.strip()]
+    cleaned: List[str] = []
+    seen: set = set()
+    for token in tokens:
+        if token not in seen:
+            cleaned.append(token)
+            seen.add(token)
+    return answer, cleaned
+
+
 def llm_yesno(question: str, purpose: str) -> str:
-    messages = [
+    base_messages = [
         {"role": "system",
          "content": "Ты аккуратный русскоязычный ассистент контроля качества. "
                     "Отвечай ТОЛЬКО одним словом: «Да» или «Нет». Никаких комментариев."},
         {"role": "user", "content": question}
     ]
-    raw = _call_openai_with_keys(messages=messages, max_tokens=4, temperature=0.0, purpose=purpose)
+    raw = _call_openai_with_keys(messages=base_messages, max_tokens=4, temperature=0.0, purpose=purpose)
     yn = _normalize_yesno(raw)
     if yn in ("Да", "Нет"):
         return yn
-    messages.append({"role": "user", "content": "Напомню: нужно одно слово — «Да» или «Нет»."})
-    raw2 = _call_openai_with_keys(messages=messages, max_tokens=4, temperature=0.0, purpose=f"{purpose} (retry)")
+    reminder_messages = base_messages + [
+        {"role": "user", "content": "Напомню: нужно одно слово — «Да» или «Нет»."}
+    ]
+    raw2 = _call_openai_with_keys(messages=reminder_messages, max_tokens=4, temperature=0.0, purpose=f"{purpose} (retry)")
     yn2 = _normalize_yesno(raw2)
     if yn2 in ("Да", "Нет"):
         return yn2
@@ -1247,8 +1363,9 @@ def build_article_list_problem_headings_prompt(headings: List[str], body: str) -
         "Сравни каждый заголовок из <HEADINGS> с языком <TEXT>. "
         "Если заголовок совпадает по языку — пропусти. "
         "Если нет — укажи точную проблему.\n"
-        "Строгий формат для каждой строки: 'проблемный заголовок' - краткое пояснение что не так и конкретно нужно определить язык <TEXT>. "
-        "Если ошибок нет — выведи «—». Главное не ошибайся, думай столько сколько нужно.\n"
+        "Начни ответ с «Да», если найдены ошибки, иначе ответь ровно «Нет».\n"
+        "Если ответ «Да», на следующих строках перечисли проблемные заголовки.\n"
+        "Каждый оформляй так: 'проблемный заголовок' — краткое пояснение.\n"
         f"\n<HEADINGS>\n{htxt or '—'}\n</HEADINGS>"
         f"\n\n<TEXT>\n{body}\n</TEXT>"
     )
@@ -1306,8 +1423,8 @@ def build_section_lang_list_bad_prompt(mt: str, md: str, mk: str, h1: str, conte
     content_block = clip((content or "").strip() or "—", EEAT_PROMPT_MAX_CHARS)
     meta_block = _format_meta_block(mt, md, mk, h1)
     return (
-        "Если найдёшь несоответствие языков, перечисли ТОЛЬКО ярлыки из набора MT | MD | MK | H1, разделяя их через « | ». "
-        "Если всё совпадает — выведи «—». Никаких пояснений.\n"
+        "Если найдёшь несоответствие языков — ответь «Да», иначе ответь ровно «Нет».\n"
+        "Если ответ «Да», перечисли ТОЛЬКО ярлыки из набора MT | MD | MK | H1, разделяя их через « | ». Никаких пояснений.\n"
         "Анализируй исключительно данные внутри тегов <META> и <CONTENT> ниже. Игнорируй язык этих инструкций."
         "\nПомни: бренды, домены и одиночные заимствованные слова не считаются сменой языка; оценивай основную часть текста.\n"
         f"\n<META>\n{meta_block}\n</META>"
@@ -1328,19 +1445,24 @@ def build_promo_extract_prompt(full_text: str) -> str:
     return (
         "Выпиши из текста только настоящие ПРОМОКОДЫ (заглавные буквенно-цифровые шаблоны). "
         "Игнорируй служебные метки («MT», «MD», «MK», «H1», «H2», «H3», «H4») и единицы "
-        "измерения («MB», «GB», «TB» и т.п.). Каждый код пиши отдельно, через « | » в "
-        "одной строке. Если промокодов нет — выведи «—».\n\n" + full_text
+        "измерения («MB», «GB», «TB» и т.п.). Если промокоды найдены, начни ответ с «Да» и на той же строке "
+        "после двоеточия перечисли их через « | ». Если промокодов нет — ответь ровно «Нет».\n\n" + full_text
     )
 
 def filter_promo_codes(raw: str) -> List[str]:
     if not raw:
         return []
-    parts = re.split(r"[|,\n]+", raw)
+    answer, tokens = _parse_yesno_list(raw)
+    if answer == "Нет":
+        return []
+    parts = tokens
+    if not parts:
+        return []
     cleaned: List[str] = []
     seen: set = set()
     for part in parts:
         token = part.strip()
-        if not token or token in ("—", "-"):
+        if not token:
             continue
         norm = re.sub(r"[^0-9A-Z]", "", token.upper())
         if not norm:
@@ -1578,15 +1700,17 @@ def validate_text_article(doc: Document) -> List[str]:
             yn = llm_yesno(prompt, purpose="Headings vs Text language (article)")
             if yn == "Нет" or script_mismatch_found:
                 prompt2 = build_article_list_problem_headings_prompt(heading_texts, body_join)
-                bad = llm_text(prompt2, purpose="List problem headings", max_tokens=256)
-                bad = re.sub(r'\s*\|\s*', ' | ', bad.strip())
-                if bad in ("—", "-", ""):
+                bad_raw = llm_text(prompt2, purpose="List problem headings", max_tokens=256)
+                bad_raw = bad_raw.strip()
+                yn_bad, bad_details = _split_yesno_details(bad_raw)
+                bad_details = re.sub(r'\s*\|\s*', ' | ', (bad_details or "").strip())
+                if yn_bad == "Нет" or not bad_details:
                     if not script_mismatch_found:
                         errors.append("Язык: заголовки не совпадают с языком основного текста.")
                 else:
                     errors.append(
                         "Язык: заголовки не совпадают с языком основного текста. "
-                        f"(Проблемные заголовки: {bad}.)"
+                        f"(Проблемные заголовки: {bad_details}.)"
                     )
     except KeysExhaustedError:
         raise
@@ -1724,15 +1848,15 @@ def validate_eeat(doc: Document) -> Tuple[List[str], Dict]:
             yn = llm_yesno(prompt, purpose=f"EEAT section language match #{idx}")
             if yn == "Нет":
                 prompt2 = build_section_lang_list_bad_prompt(mt, md, mk, h1, content_texts)
-                bad = llm_text(prompt2, purpose="EEAT list bad items", max_tokens=64).strip()
-                bad = re.sub(r'\s*\|\s*', ' | ', bad)
-                tokens = [t.strip() for t in bad.split('|') if t.strip()]
-                tokens = [t for t in tokens if t not in ("—", "-")]
-                tokens = [t for t in tokens if t.upper() not in EEAT_LANGUAGE_IGNORE_CODES]
-                if tokens:
+                bad_raw = llm_text(prompt2, purpose="EEAT list bad items", max_tokens=64).strip()
+                ans_bad, tokens = _parse_yesno_list(bad_raw)
+                filtered = [t for t in tokens if t.upper() not in EEAT_LANGUAGE_IGNORE_CODES]
+                if ans_bad == "Да" and not filtered:
+                    se.append("Язык заголовков/меты не совпадает с языком текста секции.")
+                elif filtered:
                     se.append(
                         "Язык заголовков/меты не совпадает с языком текста секции. "
-                        f"(Проблемные элементы: {' | '.join(tokens)}.)"
+                        f"(Проблемные элементы: {' | '.join(filtered)}.)"
                     )
         except KeysExhaustedError:
             raise

--- a/main.py
+++ b/main.py
@@ -1478,69 +1478,75 @@ def _format_text_for_prompt(
     return body_text
 
 
-def _format_headings_for_prompt(headings: Sequence[Tuple[Optional[int], str]]) -> str:
-    formatted: List[str] = []
-    for entry in headings:
-        lvl: Optional[int]
-        text: Optional[str]
-        if isinstance(entry, tuple) and len(entry) >= 2:
-            lvl, text = entry[0], entry[1]
-        else:
-            lvl, text = None, entry  # type: ignore[assignment]
+def _format_article_sections_for_prompt(
+    sections: Sequence[Tuple[Optional[int], str, Sequence[str]]],
+    max_chars: Optional[int] = None,
+) -> str:
+    if not sections:
+        return "—"
+
+    lines: List[str] = []
+    for idx, (lvl, heading, body_lines) in enumerate(sections, 1):
         label = f"H{lvl}" if isinstance(lvl, int) and 1 <= lvl <= 6 else "H?"
-        text_clean = strip_invisible(text or "")
-        text_clean = text_clean.strip()
-        if text_clean and len(text_clean) > 600:
-            trimmed = text_clean[:600].rstrip()
-            text_clean = (
+        heading_clean = strip_invisible(heading or "").strip()
+        if heading_clean and len(heading_clean) > 600:
+            trimmed = heading_clean[:600].rstrip()
+            heading_clean = (
                 f"{trimmed}\n"
-                f"[Обрезано: показано 600 из {len(text_clean)} символов]"
+                f"[Обрезано: показано 600 из {len(heading_clean)} символов]"
             )
-        formatted.append(f"{label}: {text_clean or '—'}")
-    return "\n".join(formatted) if formatted else "—"
+        lines.append(f"Заголовок {label}: {heading_clean or '—'}")
+
+        prepared_body = _prepare_text_lines_for_prompt(body_lines)
+        if prepared_body:
+            lines.append("Текст:")
+            lines.extend(prepared_body)
+        else:
+            lines.append("Текст: —")
+
+        if idx != len(sections):
+            lines.append("")
+
+    block = "\n".join(lines)
+    if max_chars is not None and len(block) > max_chars:
+        visible = block[:max_chars].rstrip()
+        block = (
+            f"{visible}\n"
+            f"[Обрезано: показано {max_chars} из {len(block)} символов]"
+        )
+    return block
 
 
 def build_article_headings_vs_text_prompt(
-    headings: Sequence[Tuple[Optional[int], str]],
-    body: Union[str, Sequence[str], None],
+    sections: Sequence[Tuple[Optional[int], str, Sequence[str]]],
 ) -> str:
-    htxt = _format_headings_for_prompt(headings)
-    body_block = _format_text_for_prompt(body, prefix="Text", max_chars=ART_PROMPT_MAX_CHARS)
+    section_block = _format_article_sections_for_prompt(sections, max_chars=ART_PROMPT_MAX_CHARS)
     return (
         "Ты проверяешь совпадение языка заголовков и основного текста.\n"
-        "Каждая строка в блоке <HEADINGS> начинается с H1:, H2: и т.д.\n"
-        "Смотри только в блоки <HEADINGS> и <TEXT> ниже и игнорируй язык этих инструкций.\n"
-        "Определи доминирующий язык блока <TEXT> по грамматике и служебным словам (диакритику игнорируй: á→a, ü→u и т.п.).\n"
+        "Смотри только в блок <РАЗДЕЛЫ> ниже и игнорируй язык этих инструкций.\n"
+        "Каждый раздел записан в том же порядке, что и в DOCX: сначала строка «Заголовок H#: ...», затем блок «Текст:».\n"
+        "Определи доминирующий язык каждого блока «Текст» по грамматике и служебным словам (диакритику игнорируй: á→a, ü→u и т.п.).\n"
         "Игнорируй бренды, домены/URL, аббревиатуры, числа, валюты и одиночные заимствования.\n"
-        "Сравни язык каждого заголовка из <HEADINGS> с языком <TEXT>.\n"
-        "Каждый фрагмент текста в <TEXT> начинается строкой «Text:» (если он один) или «Text #N:» (если их несколько).\n"
-        "Если хотя бы один заголовок на другом языке — ответь «Нет». Если все совпадает — ответь «Да».\n"
+        "Сравни язык строки «Заголовок ...» с языком соответствующего блока «Текст».\n"
+        "Если хотя бы один заголовок на другом языке, чем его текст — ответь «Нет». Если все совпадает — ответь «Да».\n"
         "Отвечай строго одним словом «Да» или «Нет». Никаких комментариев.\n"
-        f"\n<HEADINGS>\n{htxt}\n</HEADINGS>"
-        f"\n\n<TEXT>\n{body_block}\n</TEXT>"
+        f"\n<РАЗДЕЛЫ>\n{section_block}\n</РАЗДЕЛЫ>"
     )
 
 def build_article_list_problem_headings_prompt(
-    headings: Sequence[Tuple[Optional[int], str]],
-    body: Union[str, Sequence[str], None],
+    sections: Sequence[Tuple[Optional[int], str, Sequence[str]]],
 ) -> str:
-    htxt = _format_headings_for_prompt(headings)
-    body_block = _format_text_for_prompt(body, prefix="Text", max_chars=ART_PROMPT_MAX_CHARS)
+    section_block = _format_article_sections_for_prompt(sections, max_chars=ART_PROMPT_MAX_CHARS)
     return (
-        "Определи ДОМИНИРУЮЩИЙ язык <TEXT> СТРОГО по блоку <TEXT> ниже. Язык промпта на котором это написано не причем. Не упоминай его."
-        "Игнорируй язык этих инструкций и всё, что вне тегов. Только язык с <TEXT>. "
-        "Диакритику игнорируй (á→a, ü→u и т.п.). "
+        "Определи доминирующий язык каждого блока «Текст» строго по содержимому блока <РАЗДЕЛЫ> ниже. Язык этих инструкций игнорируй."
+        "Диакриику игнорируй (á→a, ü→u и т.п.). "
         "Игнорируй бренды/имена, домены/URL, аббревиатуры, числа/валюты и одиночные англ. заимствования.\n"
-        "Сравни каждый заголовок из <HEADINGS> с языком <TEXT>. "
-        "Каждая строка в <HEADINGS> имеет вид H1:, H2: и т.д.\n"
-        "Каждый фрагмент текста в <TEXT> начинается строкой «Text:» (если он один) или «Text #N:» (если их несколько).\n"
-        "Если заголовок совпадает по языку — пропусти. "
-        "Если нет — укажи точную проблему.\n"
+        "Сравни язык строки «Заголовок ...» с языком блока «Текст» в каждом разделе. "
+        "Если заголовок совпадает по языку — пропусти. Если нет — укажи точную проблему.\n"
         "Начни ответ с «Да», если найдены ошибки, иначе ответь ровно «Нет».\n"
         "Если ответ «Да», на следующих строках перечисли проблемные заголовки.\n"
-        "Каждый оформляй так: 'проблемный заголовок' — краткое пояснение.\n"
-        f"\n<HEADINGS>\n{htxt}\n</HEADINGS>"
-        f"\n\n<TEXT>\n{body_block}\n</TEXT>"
+        "Каждый оформляй так: 'Заголовок ...' — краткое пояснение.\n"
+        f"\n<РАЗДЕЛЫ>\n{section_block}\n</РАЗДЕЛЫ>"
     )
 
 
@@ -1763,6 +1769,8 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
     errors: List[str] = []
     headings: List[Tuple[int, str]] = []
     body_texts: List[str] = []
+    article_sections: List[Dict[str, Any]] = []
+    current_section: Optional[Dict[str, Any]] = None
 
     tag_clean = (tag or "").strip()
     section_label = f"Статья {tag_clean}" if tag_clean else "Статья"
@@ -1826,8 +1834,15 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
                 headings.append((lvl, text))
                 if len(text) > 350:
                     errors.append(f'Ошибка, текст отмечен как заголовок: "{first_words(text, 3)}"')
+                current_section = {"level": lvl, "heading": text, "body": []}
+                article_sections.append(current_section)
             else:
                 body_texts.append(text)
+                if text:
+                    if current_section is None:
+                        current_section = {"level": None, "heading": "", "body": []}
+                        article_sections.append(current_section)
+                    current_section["body"].append(text)
 
             ltype = paragraph_list_type(block, num_maps)
             if ltype == "bullet":   bullets += 1
@@ -1857,6 +1872,14 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
     if document_total_images(doc) < 2: errors.append("Картинок меньше двух (минимум 2).")
 
     try:
+        sections_for_prompt: List[Tuple[Optional[int], str, List[str]]] = []
+        for sec in article_sections:
+            heading_text = sec.get("heading") or ""
+            level = sec.get("level")
+            body_lines = [ln for ln in (sec.get("body") or []) if (ln or "").strip()]
+            if not heading_text and not body_lines:
+                continue
+            sections_for_prompt.append((level, heading_text, body_lines))
         heading_pairs = [(lvl, txt) for (lvl, txt) in headings if (txt or "").strip()]
         body_blocks = [t for t in body_texts if (t or "").strip()]
         body_sample_lines = _prepare_text_lines_for_prompt(body_blocks)
@@ -1885,10 +1908,10 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
                         "Язык: заголовок «{}» написан другим алфавитом ({}), "
                         "чем основной текст ({})".format(display, _script_label(h_script), label_body)
                     )
-            prompt = build_article_headings_vs_text_prompt(heading_pairs, body_blocks)
+            prompt = build_article_headings_vs_text_prompt(sections_for_prompt)
             yn = llm_yesno(prompt, purpose=purpose("Язык заголовков vs текст"))
             if yn == "Нет" or script_mismatch_found:
-                prompt2 = build_article_list_problem_headings_prompt(heading_pairs, body_blocks)
+                prompt2 = build_article_list_problem_headings_prompt(sections_for_prompt)
                 bad_raw = llm_text(prompt2, purpose=purpose("Проблемные заголовки"), max_tokens=256)
                 bad_raw = bad_raw.strip()
                 yn_bad, bad_details = _split_yesno_details(bad_raw)

--- a/main.py
+++ b/main.py
@@ -1454,12 +1454,6 @@ def _format_heading_text_block(
     max_chars: Optional[int] = None,
 ) -> str:
     heading_clean = strip_invisible(heading or "").strip()
-    if heading_clean and len(heading_clean) > 600:
-        trimmed = heading_clean[:600].rstrip()
-        heading_clean = (
-            f"{trimmed}\n"
-            f"[Обрезано: показано 600 из {len(heading_clean)} символов]"
-        )
 
     lines = ["Заголовки:"]
     label_clean = (label or "").strip()
@@ -1469,23 +1463,14 @@ def _format_heading_text_block(
         lines.append("—")
     else:
         lines.append(f"{label_clean}: {heading_clean or '—'}")
-    lines.append("")
-    lines.append("Текст:")
 
     prepared_body = _prepare_text_lines_for_prompt(text)
     if prepared_body:
+        lines.append("")
+        lines.append("Текст:")
         lines.extend(prepared_body)
-    else:
-        lines.append("—")
 
-    block = "\n".join(lines)
-    if max_chars is not None and len(block) > max_chars:
-        visible = block[:max_chars].rstrip()
-        block = (
-            f"{visible}\n"
-            f"[Обрезано: показано {max_chars} из {len(block)} символов]"
-        )
-    return block
+    return "\n".join(lines)
 
 
 def _format_text_for_prompt(
@@ -1518,14 +1503,7 @@ def _format_text_for_prompt(
         if idx != len(blocks):
             display_lines.append("")
 
-    body_text = "\n".join(display_lines)
-    if max_chars is not None and len(body_text) > max_chars:
-        visible = body_text[:max_chars].rstrip()
-        body_text = (
-            f"{visible}\n"
-            f"[Обрезано: показано {max_chars} из {len(body_text)} символов]"
-        )
-    return body_text
+    return "\n".join(display_lines)
 
 
 def _format_article_sections_for_prompt(
@@ -1543,14 +1521,7 @@ def _format_article_sections_for_prompt(
         if idx != len(sections):
             lines.append("")
 
-    block = "\n".join(lines)
-    if max_chars is not None and len(block) > max_chars:
-        visible = block[:max_chars].rstrip()
-        block = (
-            f"{visible}\n"
-            f"[Обрезано: показано {max_chars} из {len(block)} символов]"
-        )
-    return block
+    return "\n".join(lines)
 
 
 def build_article_headings_vs_text_prompt(
@@ -1560,7 +1531,7 @@ def build_article_headings_vs_text_prompt(
     return (
         "Ты проверяешь совпадение языка заголовков и основного текста.\n"
         "Смотри только в блок <РАЗДЕЛЫ> ниже и игнорируй язык этих инструкций.\n"
-        "Каждый раздел повторяет структуру DOCX: сначала блок «Заголовки:» со строкой вида «H#: ...», затем блок «Текст:».\n"
+        "Каждый раздел повторяет структуру DOCX: сначала блок «Заголовки:» со строкой вида «H#: ...». Если у секции есть текст, сразу после идёт блок «Текст:».\n"
         "Определи доминирующий язык каждого блока «Текст» по грамматике и служебным словам (диакритику игнорируй: á→a, ü→u и т.п.).\n"
         "Игнорируй бренды, домены/URL, аббревиатуры, числа, валюты и одиночные заимствования.\n"
         "Сравни язык строки H# из блока «Заголовки:» с языком соответствующего блока «Текст:».\n"
@@ -1577,7 +1548,8 @@ def build_article_list_problem_headings_prompt(
         "Определи доминирующий язык каждого блока «Текст» строго по содержимому блока <РАЗДЕЛЫ> ниже. Язык этих инструкций игнорируй."
         "Диакриику игнорируй (á→a, ü→u и т.п.). "
         "Игнорируй бренды/имена, домены/URL, аббревиатуры, числа/валюты и одиночные англ. заимствования.\n"
-        "Сравни язык строки H# из блока «Заголовки:» с языком блока «Текст» в каждом разделе. "
+        "Сравни язык строки H# из блока «Заголовки:» с языком блока «Текст» в каждом разделе.\n"
+        "Если у раздела нет блока «Текст:», значит там нет содержимого, и его можно пропустить.\n"
         "Если заголовок совпадает по языку — пропусти. Если нет — укажи точную проблему.\n"
         "Начни ответ с «Да», если найдены ошибки, иначе ответь ровно «Нет».\n"
         "Если ответ «Да», на следующих строках перечисли проблемные заголовки.\n"
@@ -1604,7 +1576,7 @@ def build_slug_consistency_prompt(
         "SLUG пишут без диакритики — это нормально, если он всё равно про ту же тему.",
         "Если SLUG заметно про другую тему или язык — ответь «Нет». Иначе ответь «Да».",
         "Отвечай строго одним словом «Да» или «Нет». Никаких пояснений.",
-        "Все фрагменты ниже оформлены блоками «Заголовки:» и «Текст:».",
+        "Все фрагменты ниже оформлены блоками «Заголовки:», а если у элемента есть содержимое — ещё и блоком «Текст:».",
         "",
         "<SLUG>",
         _format_heading_text_block("SLUG", slug or "—", None),
@@ -1638,7 +1610,7 @@ def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content:
         "Определи доминирующий язык <CONTENT> по грамматике и служебным словам (диакритику игнорируй: á→a, ü→u и т.п.).\n"
         "Игнорируй бренды, домены/URL, числа, валюты и одиночные заимствования.\n"
         "Сравни язык MT, MD, MK и H1 с языком <CONTENT>.\n"
-        "Каждый блок оформлен через «Заголовки:» и «Текст:», чтобы не путаться.\n"
+        "Каждый блок оформлен через «Заголовки:», а при наличии содержимого добавлен блок «Текст:», чтобы не путаться.\n"
         "Если хотя бы один элемент явно на другом языке — ответь «Нет». Если всё совпадает — ответь «Да».\n"
         "Отвечай строго одним словом «Да» или «Нет». Никаких пояснений.\n"
         f"\n<META>\n{meta_block}\n</META>"
@@ -1653,7 +1625,7 @@ def build_section_lang_list_bad_prompt(mt: str, md: str, mk: str, h1: str, conte
         "Если ответ «Да», перечисли ТОЛЬКО ярлыки из набора MT | MD | MK | H1, разделяя их через « | ». Никаких пояснений.\n"
         "Анализируй исключительно данные внутри тегов <META> и <CONTENT> ниже. Игнорируй язык этих инструкций."
         "\nПомни: бренды, домены и одиночные заимствованные слова не считаются сменой языка; оценивай основную часть текста.\n"
-        "Все блоки оформлены парами «Заголовки:» и «Текст:».\n"
+        "Каждый блок оформлен через «Заголовки:», а если в нём есть текст — добавлен блок «Текст:».\n"
         f"\n<META>\n{meta_block}\n</META>"
         f"\n\n<CONTENT>\n{_format_heading_text_block('H1', h1, content, max_chars=EEAT_PROMPT_MAX_CHARS)}\n</CONTENT>"
     )
@@ -1665,7 +1637,7 @@ def build_promo_scan_prompt(full_text: str) -> str:
         "Игнорируй служебные метки («MT», «MD», «MK», «H1», «H2», «H3», «H4») и единицы измерения («MB», «GB», «TB» и т.п.).\n"
         "Если нашёл хотя бы один промокод — ответь «Да». Если не нашёл — ответь «Нет».\n"
         "Отвечай строго одним словом «Да» или «Нет». Никаких комментариев.\n"
-        "Фрагмент ниже разбит на блоки «Заголовки:» и «Текст:» без сокращений.\n\n"
+        "Фрагмент ниже разбит на блок «Заголовки:» и, при наличии содержимого, на блок «Текст:» без сокращений.\n\n"
         f"{block}"
     )
 
@@ -1676,7 +1648,7 @@ def build_promo_extract_prompt(full_text: str) -> str:
         "Игнорируй служебные метки («MT», «MD», «MK», «H1», «H2», «H3», «H4») и единицы "
         "измерения («MB», «GB», «TB» и т.п.). Если промокоды найдены, начни ответ с «Да» и на той же строке "
         "после двоеточия перечисли их через « | ». Если промокодов нет — ответь ровно «Нет».\n\n"
-        "Фрагмент ниже разбит на блоки «Заголовки:» и «Текст:» без сокращений.\n\n"
+        "Фрагмент ниже разбит на блок «Заголовки:» и, при наличии содержимого, на блок «Текст:» без сокращений.\n\n"
         f"{block}"
     )
 
@@ -1919,10 +1891,9 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
         sections_for_prompt: List[Tuple[Optional[int], str, List[str]]] = []
         for sec in article_sections:
             heading_raw = sec.get("heading") or ""
-            heading_clean = strip_invisible(heading_raw).strip()
             level = sec.get("level")
             body_lines = [ln for ln in (sec.get("body") or []) if (ln or "").strip()]
-            if not heading_clean and not body_lines:
+            if not body_lines:
                 continue
             if not _is_meaningful_heading(heading_raw):
                 continue

--- a/main.py
+++ b/main.py
@@ -418,24 +418,14 @@ def _message_content_to_text(content: Any) -> str:
     return text.strip()
 
 
-def _format_messages_for_log(messages: List[Dict[str, Any]], max_len: int = 3200) -> str:
+def _format_messages_for_log(messages: List[Dict[str, Any]]) -> str:
     lines: List[str] = []
-    total = 0
-    truncated = False
     for msg in messages or []:
         role = str(msg.get("role") or "?")
         text = _message_content_to_text(msg.get("content"))
         if not text:
             text = "(пусто)"
-        line = f"{role}: {text}"
-        projected = total + len(line) + (1 if lines else 0)
-        if projected > max_len:
-            truncated = True
-            break
-        lines.append(line)
-        total = projected
-    if truncated:
-        lines.append(f"…(обрезано, лимит {max_len} символов)")
+        lines.append(f"{role}: {text}")
     return "\n".join(lines)
 
 
@@ -457,17 +447,41 @@ def _log_llm_chat(label: str,
         header.append(f", метод {method}")
     header.append(")")
     prompt_text = _format_messages_for_log(messages)
+    if not prompt_text:
+        prompt_text = "(пусто)"
     if error is None:
-        resp = trim(response_text or "", 600)
+        resp = (response_text or "").strip()
         if not resp:
             resp = "(пустой ответ)"
         admin_debug_log(
-            "".join(header) + f"\nЗапрос:\n{prompt_text}\nОтвет:\n{resp}"
+            "\n".join(
+                [
+                    "".join(header),
+                    BAR,
+                    "Запрос:",
+                    prompt_text,
+                    "",
+                    "Ответ:",
+                    resp,
+                ]
+            )
         )
     else:
-        err_txt = trim(_format_exception(error), 400)
+        err_txt = _format_exception(error)
         admin_debug_log(
-            "".join(header) + f"\nЗапрос:\n{prompt_text}\nОтвет:\nОшибка: {err_txt}\nПочему так?"
+            "\n".join(
+                [
+                    "".join(header),
+                    BAR,
+                    "Запрос:",
+                    prompt_text,
+                    "",
+                    "Ответ:",
+                    f"Ошибка: {err_txt}",
+                    "",
+                    "Почему так?",
+                ]
+            )
         )
 
 def _responses_input_from_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -1634,10 +1648,16 @@ def _validate_markers_in_plain_doc(doc: Document) -> List[str]:
 
     return errors
 
-def validate_text_article(doc: Document) -> List[str]:
+def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]:
     errors: List[str] = []
     headings: List[Tuple[int, str]] = []
     body_texts: List[str] = []
+
+    tag_clean = (tag or "").strip()
+    section_label = f"Статья {tag_clean}" if tag_clean else "Статья"
+
+    def purpose(task: str) -> str:
+        return f"{section_label}: {task}"
 
     def build_numbering_maps(doc: Document):
         maps = {"num_to_abs": {}, "abs_to_fmt": {}}
@@ -1753,10 +1773,10 @@ def validate_text_article(doc: Document) -> List[str]:
                         "чем основной текст ({})".format(display, _script_label(h_script), label_body)
                     )
             prompt = build_article_headings_vs_text_prompt(heading_texts, body_join)
-            yn = llm_yesno(prompt, purpose="Headings vs Text language (article)")
+            yn = llm_yesno(prompt, purpose=purpose("Язык заголовков vs текст"))
             if yn == "Нет" or script_mismatch_found:
                 prompt2 = build_article_list_problem_headings_prompt(heading_texts, body_join)
-                bad_raw = llm_text(prompt2, purpose="List problem headings", max_tokens=256)
+                bad_raw = llm_text(prompt2, purpose=purpose("Проблемные заголовки"), max_tokens=256)
                 bad_raw = bad_raw.strip()
                 yn_bad, bad_details = _split_yesno_details(bad_raw)
                 bad_details = re.sub(r'\s*\|\s*', ' | ', (bad_details or "").strip())
@@ -1776,10 +1796,10 @@ def validate_text_article(doc: Document) -> List[str]:
     try:
         full_text = " ".join([t for t in (body_texts + [t for _, t in headings]) if t])
         q1 = build_promo_scan_prompt(full_text)
-        has_code = llm_yesno(q1, purpose="Promo code scan (article)")
+        has_code = llm_yesno(q1, purpose=purpose("Промокоды — скан"))
         if has_code == "Да":
             q2 = build_promo_extract_prompt(full_text)
-            codes = llm_text(q2, purpose="Promo code extract", max_tokens=256)
+            codes = llm_text(q2, purpose=purpose("Промокоды — извлечение"), max_tokens=256)
             codes = codes.strip()
             filtered = filter_promo_codes(codes)
             if filtered:
@@ -1804,6 +1824,11 @@ def validate_text_article(doc: Document) -> List[str]:
 def validate_eeat(doc: Document) -> Tuple[List[str], Dict]:
     errors: List[str] = []
     details = {"summary": {}, "section_blocks": []}
+
+    eeat_scope_label = "EEAT (все секции)"
+
+    def eeat_purpose(task: str) -> str:
+        return f"{eeat_scope_label}: {task}"
 
     # Жёсткие правила по заголовкам
     headings_strict = []
@@ -1851,6 +1876,14 @@ def validate_eeat(doc: Document) -> Tuple[List[str], Dict]:
         h1 = (sec.get("h1") or "")
         content_texts = " ".join([t for t in (sec.get("content_texts") or []) if (t or "").strip()])
 
+        section_descriptor = f"EEAT секция #{idx}"
+        extra = (slug_clean.strip() or h1.strip())
+        if extra:
+            section_descriptor += f" ({extra})"
+
+        def section_purpose(task: str) -> str:
+            return f"{section_descriptor}: {task}"
+
         content_script = _dominant_script(content_texts)
         if content_script:
             h1_script = _dominant_script(h1)
@@ -1890,7 +1923,7 @@ def validate_eeat(doc: Document) -> Tuple[List[str], Dict]:
         # 1) slug ↔ содержимое
         try:
             prompt = build_slug_consistency_prompt(slug_clean, mt, md, mk, h1, content_texts)
-            yn = llm_yesno(prompt, purpose=f"EEAT slug consistency #{idx}")
+            yn = llm_yesno(prompt, purpose=section_purpose("SLUG ↔ содержимое"))
             if yn == "Нет":
                 se.append("SLUG не соответствует содержимому секции либо написан некорректно\n(Совет: сделайте /slug с заголовка или уточните у ChatGPT).")
         except KeysExhaustedError:
@@ -1901,10 +1934,10 @@ def validate_eeat(doc: Document) -> Tuple[List[str], Dict]:
         # 2) MT/MD/MK/H1 ↔ язык текста секции
         try:
             prompt = build_section_lang_match_prompt(mt, md, mk, h1, content_texts)
-            yn = llm_yesno(prompt, purpose=f"EEAT section language match #{idx}")
+            yn = llm_yesno(prompt, purpose=section_purpose("Язык элементов"))
             if yn == "Нет":
                 prompt2 = build_section_lang_list_bad_prompt(mt, md, mk, h1, content_texts)
-                bad_raw = llm_text(prompt2, purpose="EEAT list bad items", max_tokens=64).strip()
+                bad_raw = llm_text(prompt2, purpose=section_purpose("Проблемные элементы"), max_tokens=64).strip()
                 ans_bad, tokens = _parse_yesno_list(bad_raw)
                 filtered = [t for t in tokens if t.upper() not in EEAT_LANGUAGE_IGNORE_CODES]
                 if ans_bad == "Да" and not filtered:
@@ -1953,10 +1986,10 @@ def validate_eeat(doc: Document) -> Tuple[List[str], Dict]:
                 if ln: full.append(ln)
         all_text = " ".join(full)
         q1 = build_promo_scan_prompt(all_text)
-        has_code = llm_yesno(q1, purpose="Promo code scan (EEAT)")
+        has_code = llm_yesno(q1, purpose=eeat_purpose("Промокоды — скан"))
         if has_code == "Да":
             q2 = build_promo_extract_prompt(all_text)
-            codes = llm_text(q2, purpose="Promo code extract (EEAT)", max_tokens=256)
+            codes = llm_text(q2, purpose=eeat_purpose("Промокоды — извлечение"), max_tokens=256)
             codes = codes.strip()
             filtered = filter_promo_codes(codes)
             if filtered:
@@ -2213,7 +2246,7 @@ def validate_article_from_url(tag: str, url: str, tmpdir: Optional[str] = None) 
 
         try:
             doc = _open_doc_safe(orig_path)
-            errors = validate_text_article(doc)
+            errors = validate_text_article(doc, tag)
             if errors:
                 ok = False
                 lines.append(f"🛑 [{tag}] ОШИБКИ:")
@@ -2431,18 +2464,22 @@ async def maybe_send_admin_debug_logs(message: Message, heading: str = "🛠 Л�
     logs = admin_debug_drain()
     if not logs:
         return
-    base_limit = max(1000, 3800 - len(heading))
-    for log in logs:
-        pieces = _split_text_for_telegram(log, limit=base_limit)
-        if not pieces:
-            continue
-        total_parts = len(pieces)
-        for idx, piece in enumerate(pieces, start=1):
-            if total_parts == 1:
-                text = f"{heading}:\n{piece}"
-            else:
-                text = f"{heading} (часть {idx}/{total_parts}):\n{piece}"
-            await message.answer(text)
+    log_text = "\n\n".join(logs)
+    fd, tmp_path = tempfile.mkstemp(prefix="llm_log_", suffix=".txt")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(log_text)
+            if not log_text.endswith("\n"):
+                fh.write("\n")
+        await message.answer_document(
+            FSInputFile(tmp_path, filename="log.txt"),
+            caption=heading,
+        )
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
 
 async def setup_menu_commands(bot: Bot, chat_id: Optional[int] = None):
     await bot.set_my_commands(

--- a/main.py
+++ b/main.py
@@ -1438,6 +1438,15 @@ def _prepare_text_lines_for_prompt(text: Union[str, Sequence[str], None]) -> Lis
     return lines
 
 
+def _is_meaningful_heading(text: Optional[str]) -> bool:
+    cleaned = strip_invisible(text or "").strip()
+    if not cleaned:
+        return False
+    if all(ch in "-—–•·" for ch in cleaned):
+        return False
+    return True
+
+
 def _format_heading_text_block(
     label: str,
     heading: Union[str, None],
@@ -1452,14 +1461,22 @@ def _format_heading_text_block(
             f"[Обрезано: показано 600 из {len(heading_clean)} символов]"
         )
 
-    lines = [f"Заголовок {label}: {heading_clean or '—'}"]
+    lines = ["Заголовки:"]
+    label_clean = (label or "").strip()
+    if not label_clean:
+        label_clean = "—"
+    if label_clean.upper() == "H?" and not heading_clean:
+        lines.append("—")
+    else:
+        lines.append(f"{label_clean}: {heading_clean or '—'}")
+    lines.append("")
+    lines.append("Текст:")
 
     prepared_body = _prepare_text_lines_for_prompt(text)
     if prepared_body:
-        lines.append("Текст:")
         lines.extend(prepared_body)
     else:
-        lines.append("Текст: —")
+        lines.append("—")
 
     block = "\n".join(lines)
     if max_chars is not None and len(block) > max_chars:
@@ -1543,10 +1560,10 @@ def build_article_headings_vs_text_prompt(
     return (
         "Ты проверяешь совпадение языка заголовков и основного текста.\n"
         "Смотри только в блок <РАЗДЕЛЫ> ниже и игнорируй язык этих инструкций.\n"
-        "Каждый раздел записан в том же порядке, что и в DOCX: сначала строка «Заголовок H#: ...», затем блок «Текст:».\n"
+        "Каждый раздел повторяет структуру DOCX: сначала блок «Заголовки:» со строкой вида «H#: ...», затем блок «Текст:».\n"
         "Определи доминирующий язык каждого блока «Текст» по грамматике и служебным словам (диакритику игнорируй: á→a, ü→u и т.п.).\n"
         "Игнорируй бренды, домены/URL, аббревиатуры, числа, валюты и одиночные заимствования.\n"
-        "Сравни язык строки «Заголовок ...» с языком соответствующего блока «Текст».\n"
+        "Сравни язык строки H# из блока «Заголовки:» с языком соответствующего блока «Текст:».\n"
         "Если хотя бы один заголовок на другом языке, чем его текст — ответь «Нет». Если все совпадает — ответь «Да».\n"
         "Отвечай строго одним словом «Да» или «Нет». Никаких комментариев.\n"
         f"\n<РАЗДЕЛЫ>\n{section_block}\n</РАЗДЕЛЫ>"
@@ -1560,11 +1577,11 @@ def build_article_list_problem_headings_prompt(
         "Определи доминирующий язык каждого блока «Текст» строго по содержимому блока <РАЗДЕЛЫ> ниже. Язык этих инструкций игнорируй."
         "Диакриику игнорируй (á→a, ü→u и т.п.). "
         "Игнорируй бренды/имена, домены/URL, аббревиатуры, числа/валюты и одиночные англ. заимствования.\n"
-        "Сравни язык строки «Заголовок ...» с языком блока «Текст» в каждом разделе. "
+        "Сравни язык строки H# из блока «Заголовки:» с языком блока «Текст» в каждом разделе. "
         "Если заголовок совпадает по языку — пропусти. Если нет — укажи точную проблему.\n"
         "Начни ответ с «Да», если найдены ошибки, иначе ответь ровно «Нет».\n"
         "Если ответ «Да», на следующих строках перечисли проблемные заголовки.\n"
-        "Каждый оформляй так: 'Заголовок ...' — краткое пояснение.\n"
+        "Каждый оформляй так: 'H#: …' — краткое пояснение.\n"
         f"\n<РАЗДЕЛЫ>\n{section_block}\n</РАЗДЕЛЫ>"
     )
 
@@ -1587,7 +1604,7 @@ def build_slug_consistency_prompt(
         "SLUG пишут без диакритики — это нормально, если он всё равно про ту же тему.",
         "Если SLUG заметно про другую тему или язык — ответь «Нет». Иначе ответь «Да».",
         "Отвечай строго одним словом «Да» или «Нет». Никаких пояснений.",
-        "Все фрагменты ниже оформлены парами «Заголовок ...» и «Текст:».",
+        "Все фрагменты ниже оформлены блоками «Заголовки:» и «Текст:».",
         "",
         "<SLUG>",
         _format_heading_text_block("SLUG", slug or "—", None),
@@ -1621,7 +1638,7 @@ def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content:
         "Определи доминирующий язык <CONTENT> по грамматике и служебным словам (диакритику игнорируй: á→a, ü→u и т.п.).\n"
         "Игнорируй бренды, домены/URL, числа, валюты и одиночные заимствования.\n"
         "Сравни язык MT, MD, MK и H1 с языком <CONTENT>.\n"
-        "Каждый блок оформлен через «Заголовок ...» и «Текст:», чтобы не путаться.\n"
+        "Каждый блок оформлен через «Заголовки:» и «Текст:», чтобы не путаться.\n"
         "Если хотя бы один элемент явно на другом языке — ответь «Нет». Если всё совпадает — ответь «Да».\n"
         "Отвечай строго одним словом «Да» или «Нет». Никаких пояснений.\n"
         f"\n<META>\n{meta_block}\n</META>"
@@ -1636,30 +1653,30 @@ def build_section_lang_list_bad_prompt(mt: str, md: str, mk: str, h1: str, conte
         "Если ответ «Да», перечисли ТОЛЬКО ярлыки из набора MT | MD | MK | H1, разделяя их через « | ». Никаких пояснений.\n"
         "Анализируй исключительно данные внутри тегов <META> и <CONTENT> ниже. Игнорируй язык этих инструкций."
         "\nПомни: бренды, домены и одиночные заимствованные слова не считаются сменой языка; оценивай основную часть текста.\n"
-        "Все блоки оформлены парами «Заголовок ...» и «Текст:».\n"
+        "Все блоки оформлены парами «Заголовки:» и «Текст:».\n"
         f"\n<META>\n{meta_block}\n</META>"
         f"\n\n<CONTENT>\n{_format_heading_text_block('H1', h1, content, max_chars=EEAT_PROMPT_MAX_CHARS)}\n</CONTENT>"
     )
 
 def build_promo_scan_prompt(full_text: str) -> str:
-    block = _format_heading_text_block("H?", "—", full_text, max_chars=PROMO_MAX_CHARS)
+    block = _format_heading_text_block("H?", None, full_text, max_chars=PROMO_MAX_CHARS)
     return (
         "Определи, есть ли в тексте настоящий ПРОМОКОД — заглавный буквенно-цифровой шаблон вроде «CODE123».\n"
         "Игнорируй служебные метки («MT», «MD», «MK», «H1», «H2», «H3», «H4») и единицы измерения («MB», «GB», «TB» и т.п.).\n"
         "Если нашёл хотя бы один промокод — ответь «Да». Если не нашёл — ответь «Нет».\n"
         "Отвечай строго одним словом «Да» или «Нет». Никаких комментариев.\n"
-        "Текст передан в блоке с пометками «Заголовок H?: ...» и «Текст:».\n\n"
+        "Фрагмент ниже разбит на блоки «Заголовки:» и «Текст:» без сокращений.\n\n"
         f"{block}"
     )
 
 def build_promo_extract_prompt(full_text: str) -> str:
-    block = _format_heading_text_block("H?", "—", full_text, max_chars=PROMO_MAX_CHARS)
+    block = _format_heading_text_block("H?", None, full_text, max_chars=PROMO_MAX_CHARS)
     return (
         "Выпиши из текста только настоящие ПРОМОКОДЫ (заглавные буквенно-цифровые шаблоны). "
         "Игнорируй служебные метки («MT», «MD», «MK», «H1», «H2», «H3», «H4») и единицы "
         "измерения («MB», «GB», «TB» и т.п.). Если промокоды найдены, начни ответ с «Да» и на той же строке "
         "после двоеточия перечисли их через « | ». Если промокодов нет — ответь ровно «Нет».\n\n"
-        "Текст передан в блоке с пометками «Заголовок H?: ...» и «Текст:».\n\n"
+        "Фрагмент ниже разбит на блоки «Заголовки:» и «Текст:» без сокращений.\n\n"
         f"{block}"
     )
 
@@ -1885,10 +1902,10 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
     if not headings:
         errors.append("Нет ни одного заголовка.")
     else:
-        has_nonempty_h1 = any(lvl == 1 and (txt or "").strip() for lvl, txt in headings)
+        has_nonempty_h1 = any(lvl == 1 and _is_meaningful_heading(txt) for lvl, txt in headings)
         if not has_nonempty_h1:
             errors.append("Нет ни одного заголовка H1 (или все H1 пустые).")
-        first_nonempty = next(((lvl, txt) for (lvl, txt) in headings if (txt or "").strip()), None)
+        first_nonempty = next(((lvl, txt) for (lvl, txt) in headings if _is_meaningful_heading(txt)), None)
         if first_nonempty and first_nonempty[0] != 1:
             errors.append("Первый заголовок должен быть H1.")
         if not any(lvl == 2 for lvl,_ in headings): errors.append("Нет ни одного заголовка H2.")
@@ -1907,10 +1924,10 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
             body_lines = [ln for ln in (sec.get("body") or []) if (ln or "").strip()]
             if not heading_clean and not body_lines:
                 continue
-            if not heading_clean:
+            if not _is_meaningful_heading(heading_raw):
                 continue
             sections_for_prompt.append((level, heading_raw, body_lines))
-        heading_pairs = [(lvl, txt) for (lvl, txt) in headings if (txt or "").strip()]
+        heading_pairs = [(lvl, txt) for (lvl, txt) in headings if _is_meaningful_heading(txt)]
         body_blocks = [t for t in body_texts if (t or "").strip()]
         body_sample_lines = _prepare_text_lines_for_prompt(body_blocks)
         body_join = clip(" ".join(body_sample_lines), ART_PROMPT_MAX_CHARS)

--- a/main.py
+++ b/main.py
@@ -1473,6 +1473,22 @@ def _format_heading_text_block(
     return "\n".join(lines)
 
 
+PromoSection = Tuple[str, Optional[str], Sequence[str]]
+
+
+def _format_labeled_sections_for_prompt(sections: Sequence[PromoSection]) -> str:
+    if not sections:
+        return "—"
+
+    blocks: List[str] = []
+    for idx, (label, heading, body) in enumerate(sections, 1):
+        blocks.append(_format_heading_text_block(label, heading, body))
+        if idx != len(sections):
+            blocks.append("")
+
+    return "\n".join(blocks)
+
+
 def _format_text_for_prompt(
     text: Union[str, Sequence[str], None],
     prefix: str = "Текст",
@@ -1630,27 +1646,78 @@ def build_section_lang_list_bad_prompt(mt: str, md: str, mk: str, h1: str, conte
         f"\n\n<CONTENT>\n{_format_heading_text_block('H1', h1, content, max_chars=EEAT_PROMPT_MAX_CHARS)}\n</CONTENT>"
     )
 
-def build_promo_scan_prompt(full_text: str) -> str:
-    block = _format_heading_text_block("H?", None, full_text, max_chars=PROMO_MAX_CHARS)
+def build_promo_scan_prompt(sections: Sequence[PromoSection]) -> str:
+    block = _format_labeled_sections_for_prompt(sections)
     return (
         "Определи, есть ли в тексте настоящий ПРОМОКОД — заглавный буквенно-цифровой шаблон вроде «CODE123».\n"
         "Игнорируй служебные метки («MT», «MD», «MK», «H1», «H2», «H3», «H4») и единицы измерения («MB», «GB», «TB» и т.п.).\n"
         "Если нашёл хотя бы один промокод — ответь «Да». Если не нашёл — ответь «Нет».\n"
         "Отвечай строго одним словом «Да» или «Нет». Никаких комментариев.\n"
-        "Фрагмент ниже разбит на блок «Заголовки:» и, при наличии содержимого, на блок «Текст:» без сокращений.\n\n"
-        f"{block}"
+        "Фрагменты ниже повторяют структуру документа: каждый раздел начинается блоком «Заголовки:», а при наличии содержимого «Текст:».\n\n"
+        f"<РАЗДЕЛЫ>\n{block}\n</РАЗДЕЛЫ>"
     )
 
-def build_promo_extract_prompt(full_text: str) -> str:
-    block = _format_heading_text_block("H?", None, full_text, max_chars=PROMO_MAX_CHARS)
+
+def build_promo_extract_prompt(sections: Sequence[PromoSection]) -> str:
+    block = _format_labeled_sections_for_prompt(sections)
     return (
         "Выпиши из текста только настоящие ПРОМОКОДЫ (заглавные буквенно-цифровые шаблоны). "
         "Игнорируй служебные метки («MT», «MD», «MK», «H1», «H2», «H3», «H4») и единицы "
         "измерения («MB», «GB», «TB» и т.п.). Если промокоды найдены, начни ответ с «Да» и на той же строке "
         "после двоеточия перечисли их через « | ». Если промокодов нет — ответь ровно «Нет».\n\n"
-        "Фрагмент ниже разбит на блок «Заголовки:» и, при наличии содержимого, на блок «Текст:» без сокращений.\n\n"
-        f"{block}"
+        "Фрагменты ниже повторяют структуру документа: каждый раздел оформлен блоками «Заголовки:» и, при наличии содержимого, «Текст:».\n\n"
+        f"<РАЗДЕЛЫ>\n{block}\n</РАЗДЕЛЫ>"
     )
+
+
+def _promo_sections_from_article(article_sections: Sequence[Dict[str, Any]]) -> List[PromoSection]:
+    sections: List[PromoSection] = []
+    for sec in article_sections:
+        body_src = sec.get("body") or []
+        body_lines = [strip_invisible(ln or "").strip() for ln in body_src]
+        body_lines = [ln for ln in body_lines if ln]
+        if not body_lines:
+            continue
+        lvl = sec.get("level")
+        label = f"H{lvl}" if isinstance(lvl, int) and 1 <= lvl <= 6 else "H?"
+        heading = strip_invisible(sec.get("heading") or "")
+        sections.append((label, heading, body_lines))
+    return sections
+
+
+def _promo_sections_from_eeat(sections_data: Sequence[Dict[str, Any]]) -> List[PromoSection]:
+    sections: List[PromoSection] = []
+    for idx, sec in enumerate(sections_data, 1):
+        parts: List[str] = []
+
+        slug_raw = sec.get("slug") or ""
+        slug_clean = strip_invisible(slug_raw).strip()
+        if slug_clean:
+            parts.append(f"SLUG: {slug_clean}")
+
+        meta_lines: List[str] = []
+        for key in ("MT", "MD", "MK"):
+            val_raw = sec.get(key) or ""
+            val = strip_invisible(val_raw).strip()
+            if val:
+                meta_lines.append(f"{key}: {val}")
+        if meta_lines:
+            parts.append("\n".join(meta_lines))
+
+        content_src = sec.get("content_texts") or []
+        for chunk in content_src:
+            cleaned = strip_invisible(chunk or "").strip()
+            if cleaned:
+                parts.append(cleaned)
+
+        if not parts:
+            continue
+
+        heading_raw = strip_invisible(sec.get("h1") or "").strip()
+        heading = heading_raw or (slug_clean or f"Секция #{idx}")
+        sections.append(("H1", heading, parts))
+    return sections
+
 
 def filter_promo_codes(raw: str) -> List[str]:
     if not raw:
@@ -1948,16 +2015,17 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
         errors.append(f"Нейросетевая проверка языка заголовков/текста не выполнена: {ex}")
 
     try:
-        full_text = " ".join([t for t in (body_texts + [t for _, t in headings]) if t])
-        q1 = build_promo_scan_prompt(full_text)
-        has_code = llm_yesno(q1, purpose=purpose("Промокоды — скан"))
-        if has_code == "Да":
-            q2 = build_promo_extract_prompt(full_text)
-            codes = llm_text(q2, purpose=purpose("Промокоды — извлечение"), max_tokens=256)
-            codes = codes.strip()
-            filtered = filter_promo_codes(codes)
-            if filtered:
-                errors.append(f"Обнаружен посторонний промокод: {' | '.join(filtered)}")
+        promo_sections = _promo_sections_from_article(article_sections)
+        if promo_sections:
+            q1 = build_promo_scan_prompt(promo_sections)
+            has_code = llm_yesno(q1, purpose=purpose("Промокоды — скан"))
+            if has_code == "Да":
+                q2 = build_promo_extract_prompt(promo_sections)
+                codes = llm_text(q2, purpose=purpose("Промокоды — извлечение"), max_tokens=256)
+                codes = codes.strip()
+                filtered = filter_promo_codes(codes)
+                if filtered:
+                    errors.append(f"Обнаружен посторонний промокод: {' | '.join(filtered)}")
     except KeysExhaustedError:
         raise
     except Exception:
@@ -2133,23 +2201,17 @@ def validate_eeat(doc: Document) -> Tuple[List[str], Dict]:
 
     # Промокод — скан по всем секциям
     try:
-        full = []
-        for sec in sections:
-            for k in ("MT","MD","MK","h1"):
-                v = (sec.get(k) or "")
-                if v: full.append(f"{k.upper()}: {v}")
-            for ln in (sec.get("content_texts") or []):
-                if ln: full.append(ln)
-        all_text = " ".join(full)
-        q1 = build_promo_scan_prompt(all_text)
-        has_code = llm_yesno(q1, purpose=eeat_purpose("Промокоды — скан"))
-        if has_code == "Да":
-            q2 = build_promo_extract_prompt(all_text)
-            codes = llm_text(q2, purpose=eeat_purpose("Промокоды — извлечение"), max_tokens=256)
-            codes = codes.strip()
-            filtered = filter_promo_codes(codes)
-            if filtered:
-                errors.append(f"EEAT: обнаружен посторонний промокод: {' | '.join(filtered)}")
+        promo_sections = _promo_sections_from_eeat(sections)
+        if promo_sections:
+            q1 = build_promo_scan_prompt(promo_sections)
+            has_code = llm_yesno(q1, purpose=eeat_purpose("Промокоды — скан"))
+            if has_code == "Да":
+                q2 = build_promo_extract_prompt(promo_sections)
+                codes = llm_text(q2, purpose=eeat_purpose("Промокоды — извлечение"), max_tokens=256)
+                codes = codes.strip()
+                filtered = filter_promo_codes(codes)
+                if filtered:
+                    errors.append(f"EEAT: обнаружен посторонний промокод: {' | '.join(filtered)}")
     except KeysExhaustedError:
         raise
     except Exception:

--- a/main.py
+++ b/main.py
@@ -404,29 +404,41 @@ def _messages_preview(messages: List[Dict[str, Any]], limit: int = 600) -> str:
 
 def _message_content_to_text(content: Any) -> str:
     if isinstance(content, list):
-        texts: List[str] = []
+        pieces: List[str] = []
         for part in content:
             if isinstance(part, dict):
-                txt = str(part.get("text") or "")
+                if "text" in part:
+                    txt = part.get("text")
+                else:
+                    txt = part
             else:
-                txt = str(part)
-            if txt:
-                texts.append(txt.strip())
-        text = " ".join(texts)
-    else:
-        text = str(content or "")
-    return text.strip()
+                txt = part
+            if txt is None:
+                continue
+            s = str(txt)
+            if not s:
+                continue
+            s = s.replace("\r\n", "\n").replace("\r", "\n")
+            pieces.append(s)
+        if not pieces:
+            return ""
+        if len(pieces) == 1:
+            return pieces[0]
+        return "\n\n".join(pieces)
+    if content is None:
+        return ""
+    text = str(content)
+    return text.replace("\r\n", "\n").replace("\r", "\n")
 
 
 def _format_messages_for_log(messages: List[Dict[str, Any]]) -> str:
-    lines: List[str] = []
+    blocks: List[str] = []
     for msg in messages or []:
         role = str(msg.get("role") or "?")
         text = _message_content_to_text(msg.get("content"))
-        if not text:
-            text = "(пусто)"
-        lines.append(f"{role}: {text}")
-    return "\n".join(lines)
+        block = f"{role}:\n{text if text else '(пусто)'}"
+        blocks.append(block)
+    return "\n\n".join(blocks)
 
 
 def _format_exception(ex: BaseException) -> str:

--- a/main.py
+++ b/main.py
@@ -74,7 +74,7 @@ import traceback
 import asyncio
 import random
 import threading
-from typing import List, Tuple, Dict, Optional, Callable, Any
+from typing import List, Tuple, Dict, Optional, Callable, Any, Sequence, Union
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from aiogram import Bot, Dispatcher, F
@@ -1407,46 +1407,113 @@ def parse_eeat_sections(doc: Document):
 # =========================================================
 # ===================== ПРОМПТЫ LLM =======================
 # =========================================================
-def build_article_headings_vs_text_prompt(headings: List[str], body: str) -> str:
-    htxt = "\n".join([f"- {clean_for_prompt(h)}" for h in headings if (h or "").strip()])
-    body = clip(clean_for_prompt(body), ART_PROMPT_MAX_CHARS)
+def _prepare_text_lines_for_prompt(text: Union[str, Sequence[str], None]) -> List[str]:
+    if text is None:
+        return []
+    if isinstance(text, str):
+        candidates = [text]
+    else:
+        candidates = []
+        for chunk in text:
+            if chunk is None:
+                continue
+            candidates.append(str(chunk))
+    lines: List[str] = []
+    for chunk in candidates:
+        for line in re.split(r'(?:\r?\n)+', chunk):
+            cleaned = clean_for_prompt(line)
+            if cleaned:
+                lines.append(cleaned)
+    return lines
+
+
+def _format_text_for_prompt(
+    text: Union[str, Sequence[str], None],
+    prefix: str = "Текст:",
+    max_chars: Optional[int] = None,
+) -> str:
+    lines = _prepare_text_lines_for_prompt(text)
+    if not lines:
+        body = "—"
+    else:
+        body = "\n".join(lines)
+        if max_chars is not None:
+            body = clip(body, max_chars)
+    return f"{prefix}\n{body}"
+
+
+def _format_headings_for_prompt(headings: Sequence[Tuple[Optional[int], str]]) -> str:
+    formatted: List[str] = []
+    for entry in headings:
+        lvl: Optional[int]
+        text: Optional[str]
+        if isinstance(entry, tuple) and len(entry) >= 2:
+            lvl, text = entry[0], entry[1]
+        else:
+            lvl, text = None, entry  # type: ignore[assignment]
+        label = f"H{lvl}" if isinstance(lvl, int) and 1 <= lvl <= 6 else "H?"
+        text_clean = clean_for_prompt(text)
+        if text_clean:
+            text_clean = clip(text_clean, 400)
+        formatted.append(f"{label}: {text_clean or '—'}")
+    return "\n".join(formatted) if formatted else "—"
+
+
+def build_article_headings_vs_text_prompt(
+    headings: Sequence[Tuple[Optional[int], str]],
+    body: Union[str, Sequence[str], None],
+) -> str:
+    htxt = _format_headings_for_prompt(headings)
+    body_block = _format_text_for_prompt(body, prefix="Текст:", max_chars=ART_PROMPT_MAX_CHARS)
     return (
         "Ты проверяешь совпадение языка заголовков и основного текста.\n"
+        "Каждая строка в блоке <HEADINGS> начинается с H1:, H2: и т.д.\n"
         "Смотри только в блоки <HEADINGS> и <TEXT> ниже и игнорируй язык этих инструкций.\n"
         "Определи доминирующий язык блока <TEXT> по грамматике и служебным словам (диакритику игнорируй: á→a, ü→u и т.п.).\n"
         "Игнорируй бренды, домены/URL, аббревиатуры, числа, валюты и одиночные заимствования.\n"
         "Сравни язык каждого заголовка из <HEADINGS> с языком <TEXT>.\n"
         "Если хотя бы один заголовок на другом языке — ответь «Нет». Если все совпадает — ответь «Да».\n"
         "Отвечай строго одним словом «Да» или «Нет». Никаких комментариев.\n"
-        f"\n<HEADINGS>\n{htxt or '—'}\n</HEADINGS>"
-        f"\n\n<TEXT>\n{body}\n</TEXT>"
+        f"\n<HEADINGS>\n{htxt}\n</HEADINGS>"
+        f"\n\n<TEXT>\n{body_block}\n</TEXT>"
     )
 
-def build_article_list_problem_headings_prompt(headings: List[str], body: str) -> str:
-    htxt = "\n".join([f"- {clean_for_prompt(h)}" for h in headings if (h or "").strip()])
-    body = clip(clean_for_prompt(body), ART_PROMPT_MAX_CHARS)
+def build_article_list_problem_headings_prompt(
+    headings: Sequence[Tuple[Optional[int], str]],
+    body: Union[str, Sequence[str], None],
+) -> str:
+    htxt = _format_headings_for_prompt(headings)
+    body_block = _format_text_for_prompt(body, prefix="Текст:", max_chars=ART_PROMPT_MAX_CHARS)
     return (
         "Определи ДОМИНИРУЮЩИЙ язык <TEXT> СТРОГО по блоку <TEXT> ниже. Язык промпта на котором это написано не причем. Не упоминай его."
         "Игнорируй язык этих инструкций и всё, что вне тегов. Только язык с <TEXT>. "
         "Диакритику игнорируй (á→a, ü→u и т.п.). "
         "Игнорируй бренды/имена, домены/URL, аббревиатуры, числа/валюты и одиночные англ. заимствования.\n"
         "Сравни каждый заголовок из <HEADINGS> с языком <TEXT>. "
+        "Каждая строка в <HEADINGS> имеет вид H1:, H2: и т.д.\n"
         "Если заголовок совпадает по языку — пропусти. "
         "Если нет — укажи точную проблему.\n"
         "Начни ответ с «Да», если найдены ошибки, иначе ответь ровно «Нет».\n"
         "Если ответ «Да», на следующих строках перечисли проблемные заголовки.\n"
         "Каждый оформляй так: 'проблемный заголовок' — краткое пояснение.\n"
-        f"\n<HEADINGS>\n{htxt or '—'}\n</HEADINGS>"
-        f"\n\n<TEXT>\n{body}\n</TEXT>"
+        f"\n<HEADINGS>\n{htxt}\n</HEADINGS>"
+        f"\n\n<TEXT>\n{body_block}\n</TEXT>"
     )
 
-def build_slug_consistency_prompt(slug: str, mt: str, md: str, mk: str, h1: str, content: str) -> str:
+
+def build_slug_consistency_prompt(
+    slug: str,
+    mt: str,
+    md: str,
+    mk: str,
+    h1: str,
+    content: Union[str, Sequence[str], None],
+) -> str:
     slug = (slug or "").strip()
     mt = (mt or "").strip()
     md = (md or "").strip()
     mk = (mk or "").strip()
     h1 = (h1 or "").strip()
-    content = clip((content or "").strip(), EEAT_PROMPT_MAX_CHARS)
     body = []
     body.append("Проверь, отражает ли SLUG тему и язык секции.")
     body.append("SLUG пишут без диакритики — это нормально, если он всё равно про ту же тему.")
@@ -1460,9 +1527,7 @@ def build_slug_consistency_prompt(slug: str, mt: str, md: str, mk: str, h1: str,
     if mk: body.append(f"MK: {mk}")
     if h1: body.append(f"H1: {h1}")
     body.append("")
-    if content:
-        body.append("Текст секции:")
-        body.append(content)
+    body.append(_format_text_for_prompt(content, prefix="Текст:", max_chars=EEAT_PROMPT_MAX_CHARS))
     return "\n".join(body)
 
 def _format_meta_block(mt: str, md: str, mk: str, h1: str) -> str:
@@ -1473,8 +1538,8 @@ def _format_meta_block(mt: str, md: str, mk: str, h1: str) -> str:
     return "\n".join(lines)
 
 
-def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content: str) -> str:
-    content_block = clip((content or "").strip() or "—", EEAT_PROMPT_MAX_CHARS)
+def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content: Union[str, Sequence[str], None]) -> str:
+    content_block = _format_text_for_prompt(content, prefix="Текст:", max_chars=EEAT_PROMPT_MAX_CHARS)
     meta_block = _format_meta_block(mt, md, mk, h1)
     return (
         "Ты проверяешь, совпадает ли язык MT/MD/MK/H1 с языком текста секции.\n"
@@ -1489,8 +1554,8 @@ def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content:
     )
 
 
-def build_section_lang_list_bad_prompt(mt: str, md: str, mk: str, h1: str, content: str) -> str:
-    content_block = clip((content or "").strip() or "—", EEAT_PROMPT_MAX_CHARS)
+def build_section_lang_list_bad_prompt(mt: str, md: str, mk: str, h1: str, content: Union[str, Sequence[str], None]) -> str:
+    content_block = _format_text_for_prompt(content, prefix="Текст:", max_chars=EEAT_PROMPT_MAX_CHARS)
     meta_block = _format_meta_block(mt, md, mk, h1)
     return (
         "Если найдёшь несоответствие языков — ответь «Да», иначе ответь ровно «Нет».\n"
@@ -1746,15 +1811,17 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
     if document_total_images(doc) < 2: errors.append("Картинок меньше двух (минимум 2).")
 
     try:
-        heading_texts = [t for _, t in headings if (t or "").strip()]
-        body_join = clip(" ".join([t for t in body_texts if (t or "").strip()]), ART_PROMPT_MAX_CHARS)
+        heading_pairs = [(lvl, txt) for (lvl, txt) in headings if (txt or "").strip()]
+        body_blocks = [t for t in body_texts if (t or "").strip()]
+        body_sample_lines = _prepare_text_lines_for_prompt(body_blocks)
+        body_join = clip(" ".join(body_sample_lines), ART_PROMPT_MAX_CHARS)
         script_mismatch_found = False
-        if heading_texts and body_join:
+        if heading_pairs and body_join:
             body_script = _dominant_script(body_join)
             if body_script:
                 label_body = _script_label(body_script)
                 seen_script_notes: set = set()
-                for heading in heading_texts:
+                for _, heading in heading_pairs:
                     h_script = _dominant_script(heading)
                     if not h_script or h_script == body_script:
                         continue
@@ -1772,10 +1839,10 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
                         "Язык: заголовок «{}» написан другим алфавитом ({}), "
                         "чем основной текст ({})".format(display, _script_label(h_script), label_body)
                     )
-            prompt = build_article_headings_vs_text_prompt(heading_texts, body_join)
+            prompt = build_article_headings_vs_text_prompt(heading_pairs, body_blocks)
             yn = llm_yesno(prompt, purpose=purpose("Язык заголовков vs текст"))
             if yn == "Нет" or script_mismatch_found:
-                prompt2 = build_article_list_problem_headings_prompt(heading_texts, body_join)
+                prompt2 = build_article_list_problem_headings_prompt(heading_pairs, body_blocks)
                 bad_raw = llm_text(prompt2, purpose=purpose("Проблемные заголовки"), max_tokens=256)
                 bad_raw = bad_raw.strip()
                 yn_bad, bad_details = _split_yesno_details(bad_raw)
@@ -1874,7 +1941,9 @@ def validate_eeat(doc: Document) -> Tuple[List[str], Dict]:
         md = (sec.get("MD") or "")
         mk = (sec.get("MK") or "")
         h1 = (sec.get("h1") or "")
-        content_texts = " ".join([t for t in (sec.get("content_texts") or []) if (t or "").strip()])
+        content_lines = [t for t in (sec.get("content_texts") or []) if (t or "").strip()]
+        content_sample_lines = _prepare_text_lines_for_prompt(content_lines)
+        content_text_sample = clip(" ".join(content_sample_lines), EEAT_PROMPT_MAX_CHARS)
 
         section_descriptor = f"EEAT секция #{idx}"
         extra = (slug_clean.strip() or h1.strip())
@@ -1884,7 +1953,7 @@ def validate_eeat(doc: Document) -> Tuple[List[str], Dict]:
         def section_purpose(task: str) -> str:
             return f"{section_descriptor}: {task}"
 
-        content_script = _dominant_script(content_texts)
+        content_script = _dominant_script(content_text_sample)
         if content_script:
             h1_script = _dominant_script(h1)
             if h1_script and h1_script != content_script:
@@ -1922,7 +1991,7 @@ def validate_eeat(doc: Document) -> Tuple[List[str], Dict]:
 
         # 1) slug ↔ содержимое
         try:
-            prompt = build_slug_consistency_prompt(slug_clean, mt, md, mk, h1, content_texts)
+            prompt = build_slug_consistency_prompt(slug_clean, mt, md, mk, h1, content_lines)
             yn = llm_yesno(prompt, purpose=section_purpose("SLUG ↔ содержимое"))
             if yn == "Нет":
                 se.append("SLUG не соответствует содержимому секции либо написан некорректно\n(Совет: сделайте /slug с заголовка или уточните у ChatGPT).")
@@ -1933,10 +2002,10 @@ def validate_eeat(doc: Document) -> Tuple[List[str], Dict]:
 
         # 2) MT/MD/MK/H1 ↔ язык текста секции
         try:
-            prompt = build_section_lang_match_prompt(mt, md, mk, h1, content_texts)
+            prompt = build_section_lang_match_prompt(mt, md, mk, h1, content_lines)
             yn = llm_yesno(prompt, purpose=section_purpose("Язык элементов"))
             if yn == "Нет":
-                prompt2 = build_section_lang_list_bad_prompt(mt, md, mk, h1, content_texts)
+                prompt2 = build_section_lang_list_bad_prompt(mt, md, mk, h1, content_lines)
                 bad_raw = llm_text(prompt2, purpose=section_purpose("Проблемные элементы"), max_tokens=64).strip()
                 ans_bad, tokens = _parse_yesno_list(bad_raw)
                 filtered = [t for t in tokens if t.upper() not in EEAT_LANGUAGE_IGNORE_CODES]

--- a/main.py
+++ b/main.py
@@ -1438,9 +1438,42 @@ def _prepare_text_lines_for_prompt(text: Union[str, Sequence[str], None]) -> Lis
     return lines
 
 
+def _format_heading_text_block(
+    label: str,
+    heading: Union[str, None],
+    text: Union[str, Sequence[str], None],
+    max_chars: Optional[int] = None,
+) -> str:
+    heading_clean = strip_invisible(heading or "").strip()
+    if heading_clean and len(heading_clean) > 600:
+        trimmed = heading_clean[:600].rstrip()
+        heading_clean = (
+            f"{trimmed}\n"
+            f"[Обрезано: показано 600 из {len(heading_clean)} символов]"
+        )
+
+    lines = [f"Заголовок {label}: {heading_clean or '—'}"]
+
+    prepared_body = _prepare_text_lines_for_prompt(text)
+    if prepared_body:
+        lines.append("Текст:")
+        lines.extend(prepared_body)
+    else:
+        lines.append("Текст: —")
+
+    block = "\n".join(lines)
+    if max_chars is not None and len(block) > max_chars:
+        visible = block[:max_chars].rstrip()
+        block = (
+            f"{visible}\n"
+            f"[Обрезано: показано {max_chars} из {len(block)} символов]"
+        )
+    return block
+
+
 def _format_text_for_prompt(
     text: Union[str, Sequence[str], None],
-    prefix: str = "Text",
+    prefix: str = "Текст",
     max_chars: Optional[int] = None,
 ) -> str:
     lines = _prepare_text_lines_for_prompt(text)
@@ -1488,22 +1521,8 @@ def _format_article_sections_for_prompt(
     lines: List[str] = []
     for idx, (lvl, heading, body_lines) in enumerate(sections, 1):
         label = f"H{lvl}" if isinstance(lvl, int) and 1 <= lvl <= 6 else "H?"
-        heading_clean = strip_invisible(heading or "").strip()
-        if heading_clean and len(heading_clean) > 600:
-            trimmed = heading_clean[:600].rstrip()
-            heading_clean = (
-                f"{trimmed}\n"
-                f"[Обрезано: показано 600 из {len(heading_clean)} символов]"
-            )
-        lines.append(f"Заголовок {label}: {heading_clean or '—'}")
-
-        prepared_body = _prepare_text_lines_for_prompt(body_lines)
-        if prepared_body:
-            lines.append("Текст:")
-            lines.extend(prepared_body)
-        else:
-            lines.append("Текст: —")
-
+        block = _format_heading_text_block(label, heading, body_lines)
+        lines.append(block)
         if idx != len(sections):
             lines.append("")
 
@@ -1563,33 +1582,38 @@ def build_slug_consistency_prompt(
     md = (md or "").strip()
     mk = (mk or "").strip()
     h1 = (h1 or "").strip()
-    body = []
-    body.append("Проверь, отражает ли SLUG тему и язык секции.")
-    body.append("SLUG пишут без диакритики — это нормально, если он всё равно про ту же тему.")
-    body.append("Если SLUG заметно про другую тему или язык — ответь «Нет». Иначе ответь «Да».")
-    body.append("Отвечай строго одним словом «Да» или «Нет». Никаких пояснений.")
-    body.append("Каждый текстовый фрагмент ниже помечен строкой «Text:» (если он один) или «Text #N:» (если их несколько).")
-    body.append("")
-    body.append(slug or "—")
-    body.append("")
-    if mt: body.append(f"MT: {mt}")
-    if md: body.append(f"MD: {md}")
-    if mk: body.append(f"MK: {mk}")
-    if h1: body.append(f"H1: {h1}")
-    body.append("")
-    body.append(_format_text_for_prompt(content, prefix="Text", max_chars=EEAT_PROMPT_MAX_CHARS))
+    body = [
+        "Проверь, отражает ли SLUG тему и язык секции.",
+        "SLUG пишут без диакритики — это нормально, если он всё равно про ту же тему.",
+        "Если SLUG заметно про другую тему или язык — ответь «Нет». Иначе ответь «Да».",
+        "Отвечай строго одним словом «Да» или «Нет». Никаких пояснений.",
+        "Все фрагменты ниже оформлены парами «Заголовок ...» и «Текст:».",
+        "",
+        "<SLUG>",
+        _format_heading_text_block("SLUG", slug or "—", None),
+        "</SLUG>",
+        "",
+        "<META>",
+        _format_meta_block(mt, md, mk, h1),
+        "</META>",
+        "",
+        "<CONTENT>",
+        _format_heading_text_block("H1", h1, content, max_chars=EEAT_PROMPT_MAX_CHARS),
+        "</CONTENT>",
+    ]
     return "\n".join(body)
 
 def _format_meta_block(mt: str, md: str, mk: str, h1: str) -> str:
-    lines = ["MT: " + ((mt or "").strip() or "—"),
-             "MD: " + ((md or "").strip() or "—"),
-             "MK: " + ((mk or "").strip() or "—"),
-             "H1: " + ((h1 or "").strip() or "—")]
-    return "\n".join(lines)
+    blocks = [
+        _format_heading_text_block("MT", mt, None),
+        _format_heading_text_block("MD", md, None),
+        _format_heading_text_block("MK", mk, None),
+        _format_heading_text_block("H1", h1, None),
+    ]
+    return "\n\n".join(blocks)
 
 
 def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content: Union[str, Sequence[str], None]) -> str:
-    content_block = _format_text_for_prompt(content, prefix="Text", max_chars=EEAT_PROMPT_MAX_CHARS)
     meta_block = _format_meta_block(mt, md, mk, h1)
     return (
         "Ты проверяешь, совпадает ли язык MT/MD/MK/H1 с языком текста секции.\n"
@@ -1597,43 +1621,46 @@ def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content:
         "Определи доминирующий язык <CONTENT> по грамматике и служебным словам (диакритику игнорируй: á→a, ü→u и т.п.).\n"
         "Игнорируй бренды, домены/URL, числа, валюты и одиночные заимствования.\n"
         "Сравни язык MT, MD, MK и H1 с языком <CONTENT>.\n"
-        "Каждый фрагмент текста в <CONTENT> начинается строкой «Text:» (если он один) или «Text #N:» (если их несколько).\n"
+        "Каждый блок оформлен через «Заголовок ...» и «Текст:», чтобы не путаться.\n"
         "Если хотя бы один элемент явно на другом языке — ответь «Нет». Если всё совпадает — ответь «Да».\n"
         "Отвечай строго одним словом «Да» или «Нет». Никаких пояснений.\n"
         f"\n<META>\n{meta_block}\n</META>"
-        f"\n\n<CONTENT>\n{content_block}\n</CONTENT>"
+        f"\n\n<CONTENT>\n{_format_heading_text_block('H1', h1, content, max_chars=EEAT_PROMPT_MAX_CHARS)}\n</CONTENT>"
     )
 
 
 def build_section_lang_list_bad_prompt(mt: str, md: str, mk: str, h1: str, content: Union[str, Sequence[str], None]) -> str:
-    content_block = _format_text_for_prompt(content, prefix="Text", max_chars=EEAT_PROMPT_MAX_CHARS)
     meta_block = _format_meta_block(mt, md, mk, h1)
     return (
         "Если найдёшь несоответствие языков — ответь «Да», иначе ответь ровно «Нет».\n"
         "Если ответ «Да», перечисли ТОЛЬКО ярлыки из набора MT | MD | MK | H1, разделяя их через « | ». Никаких пояснений.\n"
         "Анализируй исключительно данные внутри тегов <META> и <CONTENT> ниже. Игнорируй язык этих инструкций."
         "\nПомни: бренды, домены и одиночные заимствованные слова не считаются сменой языка; оценивай основную часть текста.\n"
-        "Каждый фрагмент текста в <CONTENT> начинается строкой «Text:» (если он один) или «Text #N:» (если их несколько).\n"
+        "Все блоки оформлены парами «Заголовок ...» и «Текст:».\n"
         f"\n<META>\n{meta_block}\n</META>"
-        f"\n\n<CONTENT>\n{content_block}\n</CONTENT>"
+        f"\n\n<CONTENT>\n{_format_heading_text_block('H1', h1, content, max_chars=EEAT_PROMPT_MAX_CHARS)}\n</CONTENT>"
     )
 
 def build_promo_scan_prompt(full_text: str) -> str:
-    full_text = clip(clean_for_prompt(full_text), PROMO_MAX_CHARS)
+    block = _format_heading_text_block("H?", "—", full_text, max_chars=PROMO_MAX_CHARS)
     return (
         "Определи, есть ли в тексте настоящий ПРОМОКОД — заглавный буквенно-цифровой шаблон вроде «CODE123».\n"
         "Игнорируй служебные метки («MT», «MD», «MK», «H1», «H2», «H3», «H4») и единицы измерения («MB», «GB», «TB» и т.п.).\n"
         "Если нашёл хотя бы один промокод — ответь «Да». Если не нашёл — ответь «Нет».\n"
-        "Отвечай строго одним словом «Да» или «Нет». Никаких комментариев.\n\n" + full_text
+        "Отвечай строго одним словом «Да» или «Нет». Никаких комментариев.\n"
+        "Текст передан в блоке с пометками «Заголовок H?: ...» и «Текст:».\n\n"
+        f"{block}"
     )
 
 def build_promo_extract_prompt(full_text: str) -> str:
-    full_text = clip(clean_for_prompt(full_text), PROMO_MAX_CHARS)
+    block = _format_heading_text_block("H?", "—", full_text, max_chars=PROMO_MAX_CHARS)
     return (
         "Выпиши из текста только настоящие ПРОМОКОДЫ (заглавные буквенно-цифровые шаблоны). "
         "Игнорируй служебные метки («MT», «MD», «MK», «H1», «H2», «H3», «H4») и единицы "
         "измерения («MB», «GB», «TB» и т.п.). Если промокоды найдены, начни ответ с «Да» и на той же строке "
-        "после двоеточия перечисли их через « | ». Если промокодов нет — ответь ровно «Нет».\n\n" + full_text
+        "после двоеточия перечисли их через « | ». Если промокодов нет — ответь ровно «Нет».\n\n"
+        "Текст передан в блоке с пометками «Заголовок H?: ...» и «Текст:».\n\n"
+        f"{block}"
     )
 
 def filter_promo_codes(raw: str) -> List[str]:


### PR DESCRIPTION
## Summary
- add structured logging helpers so every OpenAI attempt is recorded as a dedicated chat with request/response pairs
- refactor retry flow to start fresh conversations per attempt and include clearer fallback error logs when keys are missing or exhausted
- require downstream prompts to answer with explicit yes/no markers, updating parsers for article, EEAT, and promo code checks accordingly

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68cae3709d14832bb7e980bce137c6e5