### PR TITLE
Fix prompt formatting for EEAT and promo scans

### DIFF
--- a/main.py
+++ b/main.py
@@ -1609,18 +1609,19 @@ def build_slug_consistency_prompt(
     return "\n".join(body)
 
 def _format_meta_block(mt: str, md: str, mk: str, h1: str) -> str:
-    def _fmt(label: str, value: str) -> str:
-        clean = strip_invisible(value or "").strip()
-        return f"{label}: {clean or '—'}"
+    blocks: List[str] = []
+    for label, raw_value in (("MT", mt), ("MD", md), ("MK", mk), ("H1", h1)):
+        clean_value = strip_invisible(raw_value or "").strip()
+        block_lines = [
+            "Заголовки:",
+            f"{label}: {clean_value or '—'}",
+            "",
+            "Текст:",
+            clean_value or "—",
+        ]
+        blocks.append("\n".join(block_lines))
 
-    lines = [
-        "Заголовки:",
-        _fmt("MT", mt),
-        _fmt("MD", md),
-        _fmt("MK", mk),
-        _fmt("H1", h1),
-    ]
-    return "\n".join(lines)
+    return "\n\n".join(blocks)
 
 
 def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content: Union[str, Sequence[str], None]) -> str:

--- a/main.py
+++ b/main.py
@@ -1612,13 +1612,15 @@ def _format_meta_block(mt: str, md: str, mk: str, h1: str) -> str:
     blocks: List[str] = []
     for label, raw_value in (("MT", mt), ("MD", md), ("MK", mk), ("H1", h1)):
         clean_value = strip_invisible(raw_value or "").strip()
-        block_lines = [
-            "Заголовки:",
-            f"{label}: {clean_value or '—'}",
-            "",
-            "Текст:",
-            clean_value or "—",
-        ]
+        heading_display = label.strip() or "—"
+
+        block_lines = ["Заголовки:", heading_display]
+
+        text_lines = _prepare_text_lines_for_prompt(clean_value)
+        if text_lines:
+            block_lines.extend(["", "Текст:"])
+            block_lines.extend(text_lines)
+
         blocks.append("\n".join(block_lines))
 
     return "\n\n".join(blocks)

--- a/main.py
+++ b/main.py
@@ -1609,13 +1609,18 @@ def build_slug_consistency_prompt(
     return "\n".join(body)
 
 def _format_meta_block(mt: str, md: str, mk: str, h1: str) -> str:
-    blocks = [
-        _format_heading_text_block("MT", mt, None),
-        _format_heading_text_block("MD", md, None),
-        _format_heading_text_block("MK", mk, None),
-        _format_heading_text_block("H1", h1, None),
+    def _fmt(label: str, value: str) -> str:
+        clean = strip_invisible(value or "").strip()
+        return f"{label}: {clean or '—'}"
+
+    lines = [
+        "Заголовки:",
+        _fmt("MT", mt),
+        _fmt("MD", md),
+        _fmt("MK", mk),
+        _fmt("H1", h1),
     ]
-    return "\n\n".join(blocks)
+    return "\n".join(lines)
 
 
 def build_section_lang_match_prompt(mt: str, md: str, mk: str, h1: str, content: Union[str, Sequence[str], None]) -> str:
@@ -1680,7 +1685,9 @@ def _promo_sections_from_article(article_sections: Sequence[Dict[str, Any]]) -> 
             continue
         lvl = sec.get("level")
         label = f"H{lvl}" if isinstance(lvl, int) and 1 <= lvl <= 6 else "H?"
-        heading = strip_invisible(sec.get("heading") or "")
+        heading = strip_invisible(sec.get("heading") or "").strip()
+        if not _is_meaningful_heading(heading):
+            continue
         sections.append((label, heading, body_lines))
     return sections
 


### PR DESCRIPTION
## Summary
- format EEAT meta prompts with a single heading block to mirror article sections
- drop promo scan sections that only contain placeholder headings so empty "Заголовки: —" blocks are not emitted

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68cb0bbb9370832ba82587a34c62e5d0