### PR TITLE
Add watchdog timeouts and auto link parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -1911,40 +1911,41 @@ def _keyword_match_has_boundaries(text: str, start: int, length: int) -> bool:
         if _is_keyword_word_char(nxt):
             return False
 
-        j = after_idx
-        had_space = False
-        while j < len(text) and text[j].isspace():
-            had_space = True
-            j += 1
-        if j < len(text):
-            nxt = text[j]
-            if _is_keyword_word_char(nxt):
-                return False
-            # если соединительный символ идёт сразу после ключа без пробела —
-            # продолжаем поиск, т.к. это часть другого выражения (например
-            # "win aura-casino").
-            if nxt in _KEYWORD_CONNECTOR_CHARS and not had_space and (j + 1 < len(text)):
-                k = j + 1
-                while k < len(text) and text[k].isspace():
-                    k += 1
-                if k < len(text) and _is_keyword_word_char(text[k]):
-                    return False
-
     return True
 
 
 def _keyword_in_text_with_boundaries(text: str, keyword: str) -> bool:
     if not keyword:
         return False
+    return _find_keyword_with_boundaries(text, keyword) >= 0
+
+
+def _find_keyword_with_boundaries(text: str, keyword: str) -> int:
+    if not keyword:
+        return -1
     idx = 0
     n = len(keyword)
     while True:
         idx = text.find(keyword, idx)
         if idx < 0:
-            return False
+            return -1
         if _keyword_match_has_boundaries(text, idx, n):
-            return True
+            return idx
         idx += 1
+
+
+def _iter_keyword_positions(text: str, keyword: str):
+    if not keyword:
+        return
+    start = 0
+    n = len(keyword)
+    while True:
+        idx = text.find(keyword, start)
+        if idx < 0:
+            return
+        if _keyword_match_has_boundaries(text, idx, n):
+            yield idx
+        start = idx + 1
 
 
 def _collect_mk_keywords_and_plain_text(doc: Document) -> Tuple[List[str], str]:
@@ -2249,16 +2250,52 @@ def validate_text_article(doc: Document, tag: Optional[str] = None, enforce_mk_k
             mk_keywords, body_plain = _collect_mk_keywords_and_plain_text(doc)
             if mk_keywords:
                 haystack = _normalize_for_keyword_search(body_plain)
-                missing: List[str] = []
+                keyword_norms: List[Tuple[str, str]] = []
                 for kw in mk_keywords:
                     norm_kw = _normalize_for_keyword_search(kw)
                     if not norm_kw:
                         continue
-                    if not _keyword_in_text_with_boundaries(haystack, norm_kw):
-                        missing.append(kw)
-                if missing:
-                    formatted = ", ".join(f"«{m}»" for m in missing)
-                    errors.append(f"MK: в тексте не найдены ключевые слова: {formatted}.")
+                    keyword_norms.append((kw, norm_kw))
+
+                if keyword_norms:
+                    spans_by_kw: Dict[str, List[Tuple[int, int]]] = {}
+                    for _, norm_kw in keyword_norms:
+                        positions = list(_iter_keyword_positions(haystack, norm_kw))
+                        spans_by_kw[norm_kw] = [
+                            (pos, pos + len(norm_kw)) for pos in positions
+                        ]
+
+                    missing: List[str] = []
+                    for original_kw, norm_kw in keyword_norms:
+                        spans = spans_by_kw.get(norm_kw, [])
+                        if not spans:
+                            missing.append(original_kw)
+                            continue
+
+                        independent_found = False
+                        for start, end in spans:
+                            covered = False
+                            for other_kw, other_spans in spans_by_kw.items():
+                                if other_kw == norm_kw:
+                                    continue
+                                if len(other_kw) <= len(norm_kw):
+                                    continue
+                                for o_start, o_end in other_spans:
+                                    if o_start <= start and o_end >= end:
+                                        covered = True
+                                        break
+                                if covered:
+                                    break
+                            if not covered:
+                                independent_found = True
+                                break
+
+                        if not independent_found:
+                            missing.append(original_kw)
+
+                    if missing:
+                        formatted = ", ".join(f"«{m}»" for m in missing)
+                        errors.append(f"MK: в тексте не найдены ключевые слова: {formatted}.")
         except Exception as ex:
             errors.append(f"MK: не удалось проверить ключевые слова: {ex}")
 

--- a/main.py
+++ b/main.py
@@ -1873,7 +1873,121 @@ def _validate_markers_in_plain_doc(doc: Document) -> List[str]:
 
     return errors
 
-def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]:
+
+def _normalize_for_keyword_search(text: str) -> str:
+    cleaned = strip_invisible(text or "")
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned.casefold()
+
+
+def _collect_mk_keywords_and_plain_text(doc: Document) -> Tuple[List[str], str]:
+    mk_chunks: List[str] = []
+    body_chunks: List[str] = []
+    state: Optional[str] = None
+
+    for block in iter_block_items(doc):
+        lvl = get_heading_level(block) if isinstance(block, Paragraph) else None
+        if state == "MK" and lvl is not None:
+            state = None
+
+        if isinstance(block, Paragraph):
+            raw = (block.text or "").replace("\xa0", " ")
+            lines = re.split(r'(?:\r|\n)+', raw) or [raw]
+            for raw_line in lines:
+                s = _norm_text(raw_line)
+                if not s:
+                    continue
+                matches = list(_MARKER_RE.finditer(s))
+                if matches:
+                    pos = 0
+                    for idx, match in enumerate(matches):
+                        prefix = s[pos:match.start()].strip()
+                        if prefix:
+                            if state == "MK":
+                                mk_chunks.append(prefix)
+                            elif state in ("MT", "MD"):
+                                pass
+                            else:
+                                body_chunks.append(prefix)
+
+                        marker = match.group(1)[:-1]
+                        if marker == "MT":
+                            state = "MT"
+                        elif marker == "MD":
+                            state = "MD"
+                        elif marker == "MK":
+                            state = "MK"
+
+                        payload_start = match.end()
+                        payload_end = matches[idx + 1].start() if idx + 1 < len(matches) else len(s)
+                        payload = s[payload_start:payload_end].strip()
+                        if payload:
+                            if marker == "MK":
+                                mk_chunks.append(payload)
+                            elif marker in ("MT", "MD"):
+                                pass
+                            else:
+                                body_chunks.append(payload)
+                        pos = payload_end
+
+                    if pos < len(s):
+                        tail = s[pos:].strip()
+                        if tail:
+                            if state == "MK":
+                                mk_chunks.append(tail)
+                            elif state in ("MT", "MD"):
+                                pass
+                            else:
+                                body_chunks.append(tail)
+                    continue
+
+                if state == "MK":
+                    mk_chunks.append(s)
+                elif state in ("MT", "MD"):
+                    pass
+                else:
+                    body_chunks.append(s)
+
+        elif isinstance(block, Table):
+            try:
+                segments: List[str] = []
+                for row in block.rows:
+                    for cell in row.cells:
+                        cell_text = _norm_text(cell.text)
+                        if cell_text:
+                            segments.append(cell_text)
+                if segments:
+                    combined = " ".join(segments).strip()
+                    if combined:
+                        if state == "MK":
+                            mk_chunks.append(combined)
+                        elif state in ("MT", "MD"):
+                            pass
+                        else:
+                            body_chunks.append(combined)
+            except Exception:
+                pass
+
+    mk_keywords: List[str] = []
+    seen: Set[str] = set()
+    for chunk in mk_chunks:
+        chunk_clean = strip_invisible(chunk or "").strip()
+        if not chunk_clean:
+            continue
+        for part in chunk_clean.split(','):
+            keyword = part.strip()
+            if not keyword:
+                continue
+            norm_kw = _normalize_for_keyword_search(keyword)
+            if not norm_kw or norm_kw in seen:
+                continue
+            seen.add(norm_kw)
+            mk_keywords.append(keyword)
+
+    body_text = " ".join(body_chunks)
+    return mk_keywords, body_text
+
+def validate_text_article(doc: Document, tag: Optional[str] = None, enforce_mk_keywords: bool = False) -> List[str]:
     errors: List[str] = []
     headings: List[Tuple[int, str]] = []
     body_texts: List[str] = []
@@ -2062,6 +2176,24 @@ def validate_text_article(doc: Document, tag: Optional[str] = None) -> List[str]
     except Exception:
         # не роняем проверку статей из-за служебной ошибки
         pass
+
+    if enforce_mk_keywords:
+        try:
+            mk_keywords, body_plain = _collect_mk_keywords_and_plain_text(doc)
+            if mk_keywords:
+                haystack = _normalize_for_keyword_search(body_plain)
+                missing: List[str] = []
+                for kw in mk_keywords:
+                    norm_kw = _normalize_for_keyword_search(kw)
+                    if not norm_kw:
+                        continue
+                    if norm_kw not in haystack:
+                        missing.append(kw)
+                if missing:
+                    formatted = ", ".join(f"«{m}»" for m in missing)
+                    errors.append(f"MK: в тексте не найдены ключевые слова: {formatted}.")
+        except Exception as ex:
+            errors.append(f"MK: не удалось проверить ключевые слова: {ex}")
 
     return errors
 
@@ -2473,7 +2605,7 @@ def _open_doc_safe(path: str) -> Document:
     patched = patch_docx_for_python_docx(path)
     return Document(patched)
 
-def validate_article_from_url(tag: str, url: str, tmpdir: Optional[str] = None) -> Tuple[bool, str, Optional[str]]:
+def validate_article_from_url(tag: str, url: str, tmpdir: Optional[str] = None, enforce_mk_keywords: bool = False) -> Tuple[bool, str, Optional[str]]:
     own_tmp = False
     if tmpdir is None:
         tmpdir = tempfile.mkdtemp(prefix="docxv_"); own_tmp = True
@@ -2489,7 +2621,7 @@ def validate_article_from_url(tag: str, url: str, tmpdir: Optional[str] = None) 
 
         try:
             doc = _open_doc_safe(orig_path)
-            errors = validate_text_article(doc, tag)
+            errors = validate_text_article(doc, tag, enforce_mk_keywords=enforce_mk_keywords)
             if errors:
                 ok = False
                 lines.append(f"🛑 [{tag}] ОШИБКИ:")
@@ -2556,11 +2688,13 @@ def validate_eeat_from_url(url: str, tmpdir: Optional[str] = None) -> Tuple[bool
 async def run_full_validation_async(project: str,
                                     articles: List[Tuple[str, str]],
                                     eeat_link: Optional[str] = None,
+                                    auto_generated_tags: Optional[Set[str]] = None,
                                     progress_cb: Optional[Callable[[str], Awaitable[None]]] = None) -> Tuple[bool, str, List[Tuple[str, str]], Optional[str]]:
     tmpdir = tempfile.mkdtemp(prefix="docxv_")
     sem = asyncio.Semaphore(max(1, VALIDATOR_CONCURRENCY))
     per_item_logs: List[Tuple[str, str]] = []
     zip_items: List[Tuple[str, str]] = []
+    auto_tag_set: Set[str] = set(auto_generated_tags or ())
 
     async def _emit_stage(stage: str) -> None:
         if not progress_cb:
@@ -2573,9 +2707,12 @@ async def run_full_validation_async(project: str,
             pass
 
     async def run_article(tag: str, url: str):
+        enforce_keywords = bool(auto_tag_set and tag in auto_tag_set)
         async with sem:
             if ARTICLE_VALIDATION_TIMEOUT_SEC > 0:
-                worker = asyncio.create_task(asyncio.to_thread(validate_article_from_url, tag, url, tmpdir))
+                worker = asyncio.create_task(asyncio.to_thread(
+                    validate_article_from_url, tag, url, tmpdir, enforce_keywords
+                ))
                 try:
                     return await asyncio.wait_for(worker, ARTICLE_VALIDATION_TIMEOUT_SEC)
                 except asyncio.TimeoutError:
@@ -2586,7 +2723,7 @@ async def run_full_validation_async(project: str,
                         f"Таймаут проверки статьи «{clip(tag, 80)}» спустя {ARTICLE_VALIDATION_TIMEOUT_SEC:.1f} с."
                     )
                     raise ValidationTimeoutError("article", tag, ARTICLE_VALIDATION_TIMEOUT_SEC)
-            return await asyncio.to_thread(validate_article_from_url, tag, url, tmpdir)
+            return await asyncio.to_thread(validate_article_from_url, tag, url, tmpdir, enforce_keywords)
 
     async def run_eeat(url: str):
         async with sem:
@@ -2882,7 +3019,7 @@ def _ensure_unique_auto_tag(tag: str, used: Set[str]) -> str:
     return unique
 
 
-def parse_lines_to_pairs(text: str) -> Tuple[List[Tuple[str, str]], Optional[str], List[str]]:
+def parse_lines_to_pairs(text: str) -> Tuple[List[Tuple[str, str]], Optional[str], List[str], Set[str]]:
     """
     Форматы:
       1) 'название<пробел/таб>URL_или_путь'  — в одну строку
@@ -2894,6 +3031,7 @@ def parse_lines_to_pairs(text: str) -> Tuple[List[Tuple[str, str]], Optional[str
     errors: List[str] = []
     used_tags: Set[str] = set()
     auto_counter = 0
+    auto_tags: Set[str] = set()
 
     lines = [ln for ln in (text or "").splitlines() if ln.strip()]
     i = 0
@@ -2922,6 +3060,7 @@ def parse_lines_to_pairs(text: str) -> Tuple[List[Tuple[str, str]], Optional[str
             auto_tag = _ensure_unique_auto_tag(auto_tag, used_tags)
             used_tags.add(auto_tag)
             articles.append((auto_tag, ln))
+            auto_tags.add(auto_tag)
             i += 1
             continue
 
@@ -2939,7 +3078,7 @@ def parse_lines_to_pairs(text: str) -> Tuple[List[Tuple[str, str]], Optional[str
         errors.append(f"Строка {i+1}: не распознана пара 'название\\tссылка' → «{ln}»")
         i += 1
 
-    return articles, eeat_link, errors
+    return articles, eeat_link, errors, auto_tags
 
 @dp.message(CommandStart())
 async def on_start(message: Message):
@@ -3037,7 +3176,7 @@ async def on_text(message: Message):
             return
 
         raw = message.text or ""
-        articles, eeat_link, parse_errors = parse_lines_to_pairs(raw)
+        articles, eeat_link, parse_errors, auto_tags = parse_lines_to_pairs(raw)
         if parse_errors and not articles and not eeat_link:
             await message.answer("Не удалось распознать ни одной строки:\n• " + "\n• ".join(parse_errors))
             return
@@ -3111,7 +3250,7 @@ async def on_text(message: Message):
                 await update_stage(stage)
 
             overall_ok, _full_report, per_item_logs, zip_path = await run_full_validation_async(
-                "Project", articles, eeat_link, progress_cb=relay_stage
+                "Project", articles, eeat_link, auto_generated_tags=auto_tags, progress_cb=relay_stage
             )
 
             await update_stage("Собираем отчёт")

--- a/main.py
+++ b/main.py
@@ -48,6 +48,8 @@ PROMO_IGNORE_CODES = {
 }
 EEAT_LANGUAGE_IGNORE_CODES = {"MK", "MT"}
 VALIDATOR_CONCURRENCY  = int(os.environ.get("VALIDATOR_CONCURRENCY", "8"))
+ARTICLE_VALIDATION_TIMEOUT_SEC = float(os.environ.get("ARTICLE_VALIDATION_TIMEOUT_SEC", "480"))
+EEAT_VALIDATION_TIMEOUT_SEC    = float(os.environ.get("EEAT_VALIDATION_TIMEOUT_SEC", "480"))
 
 # --- Новые параметры (Zoho OAuth: кеш и задержки) ---
 ZOHO_OAUTH_MAX_RETRIES       = int(os.environ.get("ZOHO_OAUTH_MAX_RETRIES", "3"))
@@ -76,6 +78,7 @@ import asyncio
 import random
 import threading
 from typing import List, Tuple, Dict, Optional, Callable, Any, Sequence, Union, Awaitable, Set
+from urllib.parse import urlparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from aiogram import Bot, Dispatcher, F
@@ -371,6 +374,15 @@ import contextlib
 
 class KeysExhaustedError(RuntimeError):
     pass
+
+
+class ValidationTimeoutError(RuntimeError):
+    def __init__(self, kind: str, tag: Optional[str], timeout: float):
+        self.kind = kind
+        self.tag = tag
+        self.timeout = float(timeout)
+        label = tag or kind
+        super().__init__(f"{label}: превышено время ожидания ({self.timeout:.1f} с)")
 
 def _httpx_client():
     return httpx.Client(
@@ -2562,10 +2574,34 @@ async def run_full_validation_async(project: str,
 
     async def run_article(tag: str, url: str):
         async with sem:
+            if ARTICLE_VALIDATION_TIMEOUT_SEC > 0:
+                worker = asyncio.create_task(asyncio.to_thread(validate_article_from_url, tag, url, tmpdir))
+                try:
+                    return await asyncio.wait_for(worker, ARTICLE_VALIDATION_TIMEOUT_SEC)
+                except asyncio.TimeoutError:
+                    worker.cancel()
+                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                        await worker
+                    admin_debug_log(
+                        f"Таймаут проверки статьи «{clip(tag, 80)}» спустя {ARTICLE_VALIDATION_TIMEOUT_SEC:.1f} с."
+                    )
+                    raise ValidationTimeoutError("article", tag, ARTICLE_VALIDATION_TIMEOUT_SEC)
             return await asyncio.to_thread(validate_article_from_url, tag, url, tmpdir)
 
     async def run_eeat(url: str):
         async with sem:
+            if EEAT_VALIDATION_TIMEOUT_SEC > 0:
+                worker = asyncio.create_task(asyncio.to_thread(validate_eeat_from_url, url, tmpdir))
+                try:
+                    return await asyncio.wait_for(worker, EEAT_VALIDATION_TIMEOUT_SEC)
+                except asyncio.TimeoutError:
+                    worker.cancel()
+                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                        await worker
+                    admin_debug_log(
+                        f"Таймаут EEAT-проверки спустя {EEAT_VALIDATION_TIMEOUT_SEC:.1f} с."
+                    )
+                    raise ValidationTimeoutError("eeat", "EEAT", EEAT_VALIDATION_TIMEOUT_SEC)
             return await asyncio.to_thread(validate_eeat_from_url, url, tmpdir)
 
     try:
@@ -2621,6 +2657,13 @@ async def run_full_validation_async(project: str,
 
         for idx, (tag, _url) in enumerate(articles):
             res = article_results[idx]
+            if isinstance(res, ValidationTimeoutError):
+                seconds = int(round(max(1.0, res.timeout)))
+                per_item_logs.append(
+                    (tag, f"🛑 [{tag}] Проверка прервана по лимиту времени ({seconds} сек). Попробуйте повторить позже.")
+                )
+                overall_ok = False
+                continue
             if isinstance(res, Exception):
                 per_item_logs.append((tag, f"🛑 Ошибка выполнения: {res!r}"))
                 overall_ok = False
@@ -2643,10 +2686,19 @@ async def run_full_validation_async(project: str,
             if isinstance(er, Exception):
                 if isinstance(er, KeysExhaustedError):
                     raise er
-                eeat_log = f"🛑 EEAT: ошибка выполнения — {er!r}"
-                per_item_logs.append(("EEAT", eeat_log))
-                report_lines.append(eeat_log)
-                overall_ok = False
+                elif isinstance(er, ValidationTimeoutError):
+                    seconds = int(round(max(1.0, er.timeout)))
+                    eeat_log = (
+                        f"🛑 EEAT: проверка прервана по лимиту времени ({seconds} сек). Попробуйте повторить позже."
+                    )
+                    per_item_logs.append(("EEAT", eeat_log))
+                    report_lines.append(eeat_log)
+                    overall_ok = False
+                else:
+                    eeat_log = f"🛑 EEAT: ошибка выполнения — {er!r}"
+                    per_item_logs.append(("EEAT", eeat_log))
+                    report_lines.append(eeat_log)
+                    overall_ok = False
             else:
                 ok, eeat_log, eeat_zip_src = er if er is not None else (False, "EEAT: результат не получен", None)
                 overall_ok = overall_ok and ok
@@ -2791,6 +2843,45 @@ async def setup_menu_commands(bot: Bot, chat_id: Optional[int] = None):
         except Exception:
             pass
 
+
+def _auto_tag_from_source(src: str, index: int) -> str:
+    base = ""
+    cleaned = strip_invisible((src or "")).strip()
+    if re.match(r"^https?://", cleaned, flags=re.I):
+        try:
+            parsed = urlparse(cleaned)
+        except Exception:
+            parsed = None
+        if parsed:
+            candidate = (parsed.path or "").strip("/")
+            if candidate:
+                base = candidate.split("/")[-1]
+            if not base:
+                base = parsed.netloc or ""
+    else:
+        base = os.path.splitext(os.path.basename(cleaned))[0]
+
+    base = strip_invisible(base or "").strip()
+    if not base:
+        base = f"Ссылка {index}"
+    base = re.sub(r"[\s_]+", " ", base)
+    base = re.sub(r"[\\/:*?\"<>|]+", "", base)
+    base = base.strip() or f"Ссылка {index}"
+    return clip(base, 60)
+
+
+def _ensure_unique_auto_tag(tag: str, used: Set[str]) -> str:
+    candidate = tag or "Материал"
+    if candidate.lower() == "eeat":
+        candidate = f"{candidate}-auto"
+    unique = candidate
+    suffix = 2
+    while unique in used or unique.lower() == "eeat":
+        unique = clip(f"{candidate} ({suffix})", 60)
+        suffix += 1
+    return unique
+
+
 def parse_lines_to_pairs(text: str) -> Tuple[List[Tuple[str, str]], Optional[str], List[str]]:
     """
     Форматы:
@@ -2801,6 +2892,8 @@ def parse_lines_to_pairs(text: str) -> Tuple[List[Tuple[str, str]], Optional[str
     articles: List[Tuple[str, str]] = []
     eeat_link: Optional[str] = None
     errors: List[str] = []
+    used_tags: Set[str] = set()
+    auto_counter = 0
 
     lines = [ln for ln in (text or "").splitlines() if ln.strip()]
     i = 0
@@ -2813,22 +2906,33 @@ def parse_lines_to_pairs(text: str) -> Tuple[List[Tuple[str, str]], Optional[str
 
         m = re.match(r'^(\S+)\s+(.+)$', ln)
         if m and is_url_or_path(m.group(2).strip()):
-            tag = m.group(1).strip()
+            tag = strip_invisible(m.group(1) or "").strip()
             url = m.group(2).strip()
             if tag.lower() == "eeat":
                 eeat_link = url
             else:
                 articles.append((tag, url))
+                used_tags.add(tag)
+            i += 1
+            continue
+
+        if is_url_or_path(ln):
+            auto_counter += 1
+            auto_tag = _auto_tag_from_source(ln, auto_counter)
+            auto_tag = _ensure_unique_auto_tag(auto_tag, used_tags)
+            used_tags.add(auto_tag)
+            articles.append((auto_tag, ln))
             i += 1
             continue
 
         if i + 1 < len(lines) and is_url_or_path(lines[i + 1].strip()):
-            tag = ln
+            tag = strip_invisible(ln).strip()
             url = lines[i + 1].strip()
             if tag.lower() == "eeat":
                 eeat_link = url
             else:
                 articles.append((tag, url))
+                used_tags.add(tag)
             i += 2
             continue
 
@@ -2846,6 +2950,7 @@ async def on_start(message: Message):
         await message.answer(
             "Привет! Я валидатор DOCX (Zoho Writer) с нейро‑проверками.\n\n"
             "Отправьте построчно пары `название<TAB/пробел>ссылка/путь`.\n"
+            "Можно просто отправить ссылку — название придумаю автоматически.\n"
             "`eeat <ссылка/путь>` — EEAT‑проверка.\n"
             "Ссылки: `https://writer.zoho.{dc}/writer/open/<id>` или локальные пути к .docx."
         )
@@ -2856,13 +2961,14 @@ async def on_start(message: Message):
         "— /keys_add — добавить ключи (многострочный ввод)\n"
         "— /keys_list — просмотр списка (замаскировано)\n"
         "— /keys_clear — удалить все ключи\n\n"
-        "Для запуска проверок просто пришлите пары `название  ссылка` (строка на файл/Zoho)."
+        "Для запуска проверок просто пришлите пары `название  ссылка` или одну ссылку на строку."
     )
 
 @dp.message(Command("help"))
 async def on_help(message: Message):
     await message.answer(
         "Отправьте построчно пары `название<TAB/пробел>ссылка/путь`.\n"
+        "Можно просто отправить ссылку — название подставится автоматически.\n"
         "`eeat <ссылка/путь>` — EEAT‑проверка.\n"
         "Ссылки: `https://writer.zoho.{dc}/writer/open/<id>` или локальные пути к .docx.\n\n"
         "Администратор управляет ключами OpenAI через меню команд возле строки ввода."

--- a/main.py
+++ b/main.py
@@ -1880,6 +1880,73 @@ def _normalize_for_keyword_search(text: str) -> str:
     return cleaned.casefold()
 
 
+_KEYWORD_CONNECTOR_CHARS = frozenset({
+    "-", "–", "—", "‒", "―", "−", "‑", "⁃", "﹘", "﹣", "/", "\\",
+})
+
+
+def _is_keyword_word_char(ch: str) -> bool:
+    if not ch:
+        return False
+    cat = unicodedata.category(ch)
+    if not cat:
+        return False
+    return cat[0] in ("L", "N", "M")
+
+
+def _keyword_match_has_boundaries(text: str, start: int, length: int) -> bool:
+    before_idx = start - 1
+    if before_idx >= 0:
+        prev = text[before_idx]
+        if prev in _KEYWORD_CONNECTOR_CHARS:
+            return False
+        if _is_keyword_word_char(prev):
+            return False
+
+    after_idx = start + length
+    if after_idx < len(text):
+        nxt = text[after_idx]
+        if nxt in _KEYWORD_CONNECTOR_CHARS:
+            return False
+        if _is_keyword_word_char(nxt):
+            return False
+
+        j = after_idx
+        had_space = False
+        while j < len(text) and text[j].isspace():
+            had_space = True
+            j += 1
+        if j < len(text):
+            nxt = text[j]
+            if _is_keyword_word_char(nxt):
+                return False
+            # если соединительный символ идёт сразу после ключа без пробела —
+            # продолжаем поиск, т.к. это часть другого выражения (например
+            # "win aura-casino").
+            if nxt in _KEYWORD_CONNECTOR_CHARS and not had_space and (j + 1 < len(text)):
+                k = j + 1
+                while k < len(text) and text[k].isspace():
+                    k += 1
+                if k < len(text) and _is_keyword_word_char(text[k]):
+                    return False
+
+    return True
+
+
+def _keyword_in_text_with_boundaries(text: str, keyword: str) -> bool:
+    if not keyword:
+        return False
+    idx = 0
+    n = len(keyword)
+    while True:
+        idx = text.find(keyword, idx)
+        if idx < 0:
+            return False
+        if _keyword_match_has_boundaries(text, idx, n):
+            return True
+        idx += 1
+
+
 def _collect_mk_keywords_and_plain_text(doc: Document) -> Tuple[List[str], str]:
     mk_chunks: List[str] = []
     body_chunks: List[str] = []
@@ -2187,7 +2254,7 @@ def validate_text_article(doc: Document, tag: Optional[str] = None, enforce_mk_k
                     norm_kw = _normalize_for_keyword_search(kw)
                     if not norm_kw:
                         continue
-                    if norm_kw not in haystack:
+                    if not _keyword_in_text_with_boundaries(haystack, norm_kw):
                         missing.append(kw)
                 if missing:
                     formatted = ", ".join(f"«{m}»" for m in missing)


### PR DESCRIPTION
## Summary
- add configurable watchdog timeouts for article and EEAT checks to prevent long hangs
- extend parsing to accept standalone links by auto-generating safe tags and mention in bot help text
- log timeout events for admin debugging and surface user-friendly timeout messages

## Testing
- python -m compileall codex/main.py

------
https://chatgpt.com/codex/tasks/task_e_68cc7eb8f01c832bbde314ab964d493d